### PR TITLE
refactor: Rework internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@cloudflare/workers-types": "^4.20241216.0",
     "@types/pg": "^8.11.10",
     "typescript": "^5.7.2",
-    "wrangler": "^3.96.3"
+    "wrangler": "^3.96.0"
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240925.0",
+    "@cloudflare/workers-types": "^4.20241216.0",
     "@types/pg": "^8.11.10",
-    "typescript": "^5.5.2",
-    "wrangler": "^3.60.3"
+    "typescript": "^5.7.2",
+    "wrangler": "^3.96.3"
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 5.9.6
       mongodb:
         specifier: ^6.11.0
-        version: 6.11.0
+        version: 6.12.0
       mysql2:
         specifier: ^3.11.4
-        version: 3.11.4
+        version: 3.11.5
       node-sql-parser:
         specifier: ^4.18.0
         version: 4.18.0
@@ -34,17 +34,17 @@ importers:
         version: 8.13.1
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20240925.0
-        version: 4.20240925.0
+        specifier: ^4.20241216.0
+        version: 4.20241216.0
       '@types/pg':
         specifier: ^8.11.10
         version: 8.11.10
       typescript:
-        specifier: ^5.5.2
-        version: 5.6.2
+        specifier: ^5.7.2
+        version: 5.7.2
       wrangler:
-        specifier: ^3.60.3
-        version: 3.78.12(@cloudflare/workers-types@4.20240925.0)
+        specifier: ^3.96.0
+        version: 3.96.0(@cloudflare/workers-types@4.20241216.0)
 
 packages:
 
@@ -52,42 +52,38 @@ packages:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
 
-  '@cloudflare/workerd-darwin-64@1.20240925.0':
-    resolution: {integrity: sha512-KdLnSXuzB65CbqZPm+qYzk+zkQ1tUNPaaRGYVd/jPYAxwwtfTUQdQ+ahDPwVVs2tmQELKy7ZjQjf2apqSWUfjw==}
+  '@cloudflare/workerd-darwin-64@1.20241205.0':
+    resolution: {integrity: sha512-TArEZkSZkHJyEwnlWWkSpCI99cF6lJ14OVeEoI9Um/+cD9CKZLM9vCmsLeKglKheJ0KcdCnkA+DbeD15t3VaWg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20240925.0':
-    resolution: {integrity: sha512-MiQ6uUmCXjsXgWNV+Ock2tp2/tYqNJGzjuaH6jFioeRF+//mz7Tv7J7EczOL4zq+TH8QFOh0/PUsLyazIWVGng==}
+  '@cloudflare/workerd-darwin-arm64@1.20241205.0':
+    resolution: {integrity: sha512-u5eqKa9QRdA8MugfgCoD+ADDjY6EpKbv3hSYJETmmUh17l7WXjWBzv4pUvOKIX67C0UzMUy4jZYwC53MymhX3w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20240925.0':
-    resolution: {integrity: sha512-Rjix8jsJMfsInmq3Hm3fmiRQ+rwzuWRPV1pg/OWhMSfNP7Qp2RCU+RGkhgeR9Z5eNAje0Sn2BMrFq4RvF9/yRA==}
+  '@cloudflare/workerd-linux-64@1.20241205.0':
+    resolution: {integrity: sha512-OYA7S5zpumMamWEW+IhhBU6YojIEocyE5X/YFPiTOCrDE3dsfr9t6oqNE7hxGm1VAAu+Irtl+a/5LwmBOU681w==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20240925.0':
-    resolution: {integrity: sha512-VYIPeMHQRtbwQoIjUwS/zULlywPxyDvo46XkTpIW5MScEChfqHvAYviQ7TzYGx6Q+gmZmN+DUB2KOMx+MEpCxA==}
+  '@cloudflare/workerd-linux-arm64@1.20241205.0':
+    resolution: {integrity: sha512-qAzecONjFJGIAVJZKExQ5dlbic0f3d4A+GdKa+H6SoUJtPaWiE3K6WuePo4JOT7W3/Zfh25McmX+MmpMUUcM5Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20240925.0':
-    resolution: {integrity: sha512-C8peGvaU5R51bIySi1VbyfRgwNSSRknqoFSnSbSBI3uTN3THTB3UnmRKy7GXJDmyjgXuT9Pcs1IgaWNubLtNtw==}
+  '@cloudflare/workerd-windows-64@1.20241205.0':
+    resolution: {integrity: sha512-BEab+HiUgCdl6GXAT7EI2yaRtDPiRJlB94XLvRvXi1ZcmQqsrq6awGo6apctFo4WUL29V7c09LxmN4HQ3X2Tvg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-shared@0.5.4':
-    resolution: {integrity: sha512-PNL/0TjKRdUHa1kwgVdqUNJVZ9ez4kacsi8omz+gv859EvJmsVuGiMAClY2YfJnC9LVKhKCcjqmFgKNXG9/IXA==}
-    engines: {node: '>=16.7.0'}
-
-  '@cloudflare/workers-types@4.20240925.0':
-    resolution: {integrity: sha512-KpqyRWvanEuXgBTKYFzRp4NsWOEcswxjsPRSre1zYQcODmc8PUrraVHQUmgvkJgv3FzB+vI9xm7J6oE4MmZHCA==}
+  '@cloudflare/workers-types@4.20241216.0':
+    resolution: {integrity: sha512-PGIINXS+aE9vD2GYyWXfRG+VyxxceRkGDCoPxqwUweh1Bfv75HVotyL/adJ7mRVwh3XZDifGBdTaLReTT+Fcog==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -313,8 +309,8 @@ packages:
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
 
-  '@types/node@22.7.4':
-    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+  '@types/node@22.10.2':
+    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
 
   '@types/pg@8.11.10':
     resolution: {integrity: sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==}
@@ -332,14 +328,10 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.12.1:
-    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
 
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
@@ -352,30 +344,22 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-
-  bson@6.10.0:
-    resolution: {integrity: sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==}
+  bson@6.10.1:
+    resolution: {integrity: sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==}
     engines: {node: '>=16.20.1'}
 
   capnp-ts@0.7.0:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@4.0.2:
+    resolution: {integrity: sha512-/b57FK+bblSU+dfewfFe0rT1YjVDfOmeLQwCAuC+vwvgLkXboATqqmy+Ipux6JrF6L5joe5CBnFOw+gLWH6yKg==}
+    engines: {node: '>= 14.16.0'}
 
-  cookie@0.5.0:
-    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   data-uri-to-buffer@2.0.2:
@@ -385,8 +369,11 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -425,10 +412,6 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -446,10 +429,6 @@ packages:
 
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -471,28 +450,15 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
-  is-core-module@2.15.1:
-    resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
+  is-core-module@2.16.0:
+    resolution: {integrity: sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==}
     engines: {node: '>= 0.4'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  itty-time@1.0.6:
+    resolution: {integrity: sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==}
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
@@ -502,6 +468,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   long@5.2.3:
@@ -526,8 +493,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  miniflare@3.20240925.0:
-    resolution: {integrity: sha512-2LmQbKHf0n6ertUKhT+Iltixi53giqDH7P71+wCir3OnGyXIODqYwOECx1mSDNhYThpxM2dav8UdPn6SQiMoXw==}
+  miniflare@3.20241205.0:
+    resolution: {integrity: sha512-Z0cTtIf6ZrcAJ3SrOI9EUM3s4dkGhNeU6Ubl8sroYhsPVD+rtz3m5+p6McHFWCkcMff1o60X5XEKVTmkz0gbpA==}
     engines: {node: '>=16.13'}
     hasBin: true
 
@@ -537,12 +504,12 @@ packages:
   mongodb-connection-string-url@3.0.1:
     resolution: {integrity: sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==}
 
-  mongodb@6.11.0:
-    resolution: {integrity: sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==}
+  mongodb@6.12.0:
+    resolution: {integrity: sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==}
     engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
       gcp-metadata: ^5.2.0
       kerberos: ^2.0.1
       mongodb-client-encryption: '>=6.0.0 <7'
@@ -571,16 +538,16 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  mysql2@3.11.4:
-    resolution: {integrity: sha512-Z2o3tY4Z8EvSRDwknaC40MdZ3+m0sKbpnXrShQLdxPrAvcNli7jLrD2Zd2IzsRMw4eK9Yle500FDmlkIqp+krg==}
+  mysql2@3.11.5:
+    resolution: {integrity: sha512-0XFu8rUmFN9vC0ME36iBvCUObftiMHItrYFhlCRvFWbLgpNqtC4Br/NmZX1HNCszxT0GGy5QtP+k3Q3eCJPaYA==}
     engines: {node: '>= 8.0'}
 
   named-placeholders@1.1.3:
     resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
     engines: {node: '>=12.0.0'}
 
-  nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -602,10 +569,6 @@ packages:
   node-sql-parser@4.18.0:
     resolution: {integrity: sha512-2YEOR5qlI1zUFbGMLKNfsrR5JUvFg9LxIRVE+xJe962pfVLH0rnItqLzv96XVs1Y1UIR8FxsXAuvX/lYAWZ2BQ==}
     engines: {node: '>=8'}
-
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
@@ -664,10 +627,6 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -713,16 +672,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
 
-  resolve.exports@2.0.2:
-    resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
-    engines: {node: '>=10'}
-
-  resolve@1.22.8:
-    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+  resolve@1.22.9:
+    resolution: {integrity: sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==}
     hasBin: true
 
   rollup-plugin-inject@3.0.2:
@@ -775,19 +730,15 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   tr46@4.1.1:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -799,15 +750,15 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  unenv-nightly@2.0.0-20240919-125358-9a64854:
-    resolution: {integrity: sha512-XjsgUTrTHR7iw+k/SRTNjh6EQgwpC9voygnoCJo5kh4hKqsSDHUW84MhL9EsHTNfLctvVBHaSw8e2k3R2fKXsQ==}
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
+    resolution: {integrity: sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -824,17 +775,17 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  workerd@1.20240925.0:
-    resolution: {integrity: sha512-/Jj6+yLwfieZGEt3Kx4+5MoufuC3g/8iFaIh4MPBNGJOGYmdSKXvgCqz09m2+tVCYnysRfbq2zcbVxJRBfOCqQ==}
+  workerd@1.20241205.0:
+    resolution: {integrity: sha512-vso/2n0c5SdBDWiD+Sx5gM7unA6SiZXRVUHDqH1euoP/9mFVHZF8icoYsNLB87b/TX8zNgpae+I5N/xFpd9v0g==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.78.12:
-    resolution: {integrity: sha512-a/xk/N04IvOGk9J+BLkiFg42GDyPS+0BiJimbrHsbX+CDr8Iqq3HNMEyQld+6zbmq01u/gmc8S7GKVR9vDx4+g==}
+  wrangler@3.96.0:
+    resolution: {integrity: sha512-KjbHTUnwTa5eKl3hzv2h6nHBfAsbUkdurL7f6Y288/Bdn6tcEis13jLVR/nw/eWa3tNCBG1xOMZJboUyzWcC1g==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20240925.0
+      '@cloudflare/workers-types': ^4.20241205.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -855,14 +806,14 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  xxhash-wasm@1.0.2:
-    resolution: {integrity: sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==}
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
-  youch@3.3.3:
-    resolution: {integrity: sha512-qSFXUk3UZBLfggAW3dJKg0BMblG5biqSF8M34E06o5CSsZtH92u9Hqmj2RzGiHDi64fhe83+4tENFP2DB6t6ZA==}
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
 snapshots:
 
@@ -870,27 +821,22 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/workerd-darwin-64@1.20240925.0':
+  '@cloudflare/workerd-darwin-64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20240925.0':
+  '@cloudflare/workerd-darwin-arm64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20240925.0':
+  '@cloudflare/workerd-linux-64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20240925.0':
+  '@cloudflare/workerd-linux-arm64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20240925.0':
+  '@cloudflare/workerd-windows-64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workers-shared@0.5.4':
-    dependencies:
-      mime: 3.0.0
-      zod: 3.23.8
-
-  '@cloudflare/workers-types@4.20240925.0': {}
+  '@cloudflare/workers-types@4.20241216.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -1051,15 +997,15 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.10.2
 
-  '@types/node@22.7.4':
+  '@types/node@22.10.2':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@types/pg@8.11.10':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.10.2
       pg-protocol: 1.7.0
       pg-types: 4.0.2
 
@@ -1071,18 +1017,13 @@ snapshots:
 
   '@types/ws@8.5.13':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.10.2
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
 
-  acorn@8.12.1: {}
-
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
+  acorn@8.14.0: {}
 
   as-table@1.0.55:
     dependencies:
@@ -1092,42 +1033,30 @@ snapshots:
 
   big-integer@1.6.52: {}
 
-  binary-extensions@2.3.0: {}
-
   blake3-wasm@2.1.5: {}
 
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
-  bson@6.10.0: {}
+  bson@6.10.1: {}
 
   capnp-ts@0.7.0:
     dependencies:
-      debug: 4.3.7
-      tslib: 2.7.0
+      debug: 4.4.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  chokidar@3.6.0:
+  chokidar@4.0.2:
     dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
+      readdirp: 4.0.2
 
-  cookie@0.5.0: {}
+  cookie@0.7.2: {}
 
   data-uri-to-buffer@2.0.2: {}
 
   data-uri-to-buffer@4.0.1: {}
 
-  debug@4.3.7:
+  date-fns@4.1.0: {}
+
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
@@ -1173,10 +1102,6 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
-
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -1194,10 +1119,6 @@ snapshots:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
 
@@ -1220,23 +1141,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
-  is-core-module@2.15.1:
+  is-core-module@2.16.0:
     dependencies:
       hasown: 2.0.2
 
-  is-extglob@2.1.1: {}
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-number@7.0.0: {}
-
   is-property@1.0.2: {}
+
+  itty-time@1.0.6: {}
 
   jose@5.9.6: {}
 
@@ -1269,20 +1180,20 @@ snapshots:
 
   mime@3.0.0: {}
 
-  miniflare@3.20240925.0:
+  miniflare@3.20241205.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.12.1
+      acorn: 8.14.0
       acorn-walk: 8.3.4
       capnp-ts: 0.7.0
       exit-hook: 2.2.1
       glob-to-regexp: 0.4.1
       stoppable: 1.1.0
       undici: 5.28.4
-      workerd: 1.20240925.0
+      workerd: 1.20241205.0
       ws: 8.18.0
-      youch: 3.3.3
-      zod: 3.23.8
+      youch: 3.3.4
+      zod: 3.24.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1295,17 +1206,17 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb@6.11.0:
+  mongodb@6.12.0:
     dependencies:
       '@mongodb-js/saslprep': 1.1.9
-      bson: 6.10.0
+      bson: 6.10.1
       mongodb-connection-string-url: 3.0.1
 
   ms@2.1.3: {}
 
   mustache@4.2.0: {}
 
-  mysql2@3.11.4:
+  mysql2@3.11.5:
     dependencies:
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
@@ -1321,7 +1232,7 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
-  nanoid@3.3.7: {}
+  nanoid@3.3.8: {}
 
   neo-async@2.6.2: {}
 
@@ -1338,8 +1249,6 @@ snapshots:
   node-sql-parser@4.18.0:
     dependencies:
       big-integer: 1.6.52
-
-  normalize-path@3.0.0: {}
 
   obuf@1.1.2: {}
 
@@ -1398,8 +1307,6 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
-  picomatch@2.3.1: {}
-
   postgres-array@2.0.0: {}
 
   postgres-array@3.0.2: {}
@@ -1428,15 +1335,11 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
+  readdirp@4.0.2: {}
 
-  resolve.exports@2.0.2: {}
-
-  resolve@1.22.8:
+  resolve@1.22.9:
     dependencies:
-      is-core-module: 2.15.1
+      is-core-module: 2.16.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -1484,30 +1387,26 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
   tr46@4.1.1:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.7.0: {}
+  tslib@2.8.1: {}
 
-  typescript@5.6.2: {}
+  typescript@5.7.2: {}
 
   ufo@1.5.4: {}
 
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  unenv-nightly@2.0.0-20240919-125358-9a64854:
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
     dependencies:
       defu: 6.1.4
       ohash: 1.1.4
@@ -1525,35 +1424,35 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workerd@1.20240925.0:
+  workerd@1.20241205.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20240925.0
-      '@cloudflare/workerd-darwin-arm64': 1.20240925.0
-      '@cloudflare/workerd-linux-64': 1.20240925.0
-      '@cloudflare/workerd-linux-arm64': 1.20240925.0
-      '@cloudflare/workerd-windows-64': 1.20240925.0
+      '@cloudflare/workerd-darwin-64': 1.20241205.0
+      '@cloudflare/workerd-darwin-arm64': 1.20241205.0
+      '@cloudflare/workerd-linux-64': 1.20241205.0
+      '@cloudflare/workerd-linux-arm64': 1.20241205.0
+      '@cloudflare/workerd-windows-64': 1.20241205.0
 
-  wrangler@3.78.12(@cloudflare/workers-types@4.20240925.0):
+  wrangler@3.96.0(@cloudflare/workers-types@4.20241216.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/workers-shared': 0.5.4
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
-      chokidar: 3.6.0
+      chokidar: 4.0.2
+      date-fns: 4.1.0
       esbuild: 0.17.19
-      miniflare: 3.20240925.0
-      nanoid: 3.3.7
+      itty-time: 1.0.6
+      miniflare: 3.20241205.0
+      nanoid: 3.3.8
       path-to-regexp: 6.3.0
-      resolve: 1.22.8
-      resolve.exports: 2.0.2
+      resolve: 1.22.9
       selfsigned: 2.4.1
       source-map: 0.6.1
-      unenv: unenv-nightly@2.0.0-20240919-125358-9a64854
-      workerd: 1.20240925.0
-      xxhash-wasm: 1.0.2
+      unenv: unenv-nightly@2.0.0-20241204-140205-a5d5190
+      workerd: 1.20241205.0
+      xxhash-wasm: 1.1.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20240925.0
+      '@cloudflare/workers-types': 4.20241216.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -1564,12 +1463,12 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  xxhash-wasm@1.0.2: {}
+  xxhash-wasm@1.1.0: {}
 
-  youch@3.3.3:
+  youch@3.3.4:
     dependencies:
-      cookie: 0.5.0
+      cookie: 0.7.2
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod@3.23.8: {}
+  zod@3.24.1: {}

--- a/src/allowlist/index.ts
+++ b/src/allowlist/index.ts
@@ -1,5 +1,5 @@
 import { StarbaseDBConfiguration } from "../handler";
-import { DataSource } from "../types";
+import { DataSource, QueryResult } from "../types";
 
 const parser = new (require("node-sql-parser").Parser)();
 
@@ -17,7 +17,7 @@ function normalizeSQL(sql: string) {
 async function loadAllowlist(dataSource: DataSource): Promise<string[]> {
   try {
     const statement = "SELECT sql_statement FROM tmp_allowlist_queries";
-    const result = await dataSource.rpc.executeQuery({ sql: statement });
+    const result = await dataSource.rpc.executeQuery({ sql: statement }) as QueryResult[]
     return result.map((row) => String(row.sql_statement));
   } catch (error) {
     console.error("Error loading allowlist:", error);

--- a/src/allowlist/index.ts
+++ b/src/allowlist/index.ts
@@ -1,86 +1,95 @@
-import { HandlerConfig } from "../handler";
+import { StarbaseDBConfiguration } from "../handler";
 import { DataSource } from "../types";
 
-const parser = new (require('node-sql-parser').Parser)();
+const parser = new (require("node-sql-parser").Parser)();
 
 let allowlist: string[] | null = null;
 let normalizedAllowlist: any[] | null = null;
 
 function normalizeSQL(sql: string) {
-    // Remove trailing semicolon. This allows a user to send a SQL statement that has
-    // a semicolon where the allow list might not include it but both statements can
-    // equate to being the same. AST seems to have an issue with matching the difference
-    // when included in one query vs another.
-    return sql.trim().replace(/;\s*$/, '');
+  // Remove trailing semicolon. This allows a user to send a SQL statement that has
+  // a semicolon where the allow list might not include it but both statements can
+  // equate to being the same. AST seems to have an issue with matching the difference
+  // when included in one query vs another.
+  return sql.trim().replace(/;\s*$/, "");
 }
 
-async function loadAllowlist(dataSource?: DataSource): Promise<string[]> {
-    try {
-        const statement = 'SELECT sql_statement FROM tmp_allowlist_queries'
-        const result = await dataSource?.internalConnection?.durableObject.executeQuery(statement, [], false) as any[];
-        return result.map((row: any) => row.sql_statement);
-    } catch (error) {
-        console.error('Error loading allowlist:', error);
-        return [];
-    }
+async function loadAllowlist(dataSource: DataSource): Promise<string[]> {
+  try {
+    const statement = "SELECT sql_statement FROM tmp_allowlist_queries";
+    const result = await dataSource.rpc.executeQuery({ sql: statement });
+    return result.map((row) => String(row.sql_statement));
+  } catch (error) {
+    console.error("Error loading allowlist:", error);
+    return [];
+  }
 }
 
-export async function isQueryAllowed(sql: string, isEnabled: boolean, dataSource?: DataSource, config?: HandlerConfig): Promise<boolean | Error> {
-    // If the feature is not turned on then by default the query is allowed
-    if (!isEnabled) return true;
+export async function isQueryAllowed(opts: {
+  sql: string;
+  isEnabled: boolean;
+  dataSource: DataSource;
+  config: StarbaseDBConfiguration;
+}): Promise<boolean | Error> {
+  const { sql, isEnabled, dataSource, config } = opts;
 
-    // If we are using the administrative AUTHORIZATION token value, this request is allowed.
-    // We want database UI's to be able to have more free reign to run queries so we can load
-    // tables, run queries, and more. If you want to block queries with the allowlist then we
-    // advise you to do so by implementing user authentication with JWT.
-    if (dataSource?.request.headers.get('Authorization') === `Bearer ${config?.adminAuthorizationToken}`) {
-        return true;
+  // If the feature is not turned on then by default the query is allowed
+  if (!isEnabled) return true;
+
+  // If we are using the administrative AUTHORIZATION token value, this request is allowed.
+  // We want database UI's to be able to have more free reign to run queries so we can load
+  // tables, run queries, and more. If you want to block queries with the allowlist then we
+  // advise you to do so by implementing user authentication with JWT.
+  if (config.role === "admin") {
+    return true;
+  }
+
+  allowlist = await loadAllowlist(dataSource);
+  normalizedAllowlist = allowlist.map((query) =>
+    parser.astify(normalizeSQL(query))
+  );
+
+  try {
+    if (!sql) {
+      return Error("No SQL provided for allowlist check");
     }
 
-    allowlist = await loadAllowlist(dataSource);
-    normalizedAllowlist = allowlist.map(query => parser.astify(normalizeSQL(query)));
-    
-    try {
-        if (!sql) {
-            return Error('No SQL provided for allowlist check')
+    const normalizedQuery = parser.astify(normalizeSQL(sql));
+
+    // Compare ASTs while ignoring specific values
+    const isCurrentAllowed = normalizedAllowlist?.some((allowedQuery) => {
+      // Create deep copies to avoid modifying original ASTs
+      const allowedAst = JSON.parse(JSON.stringify(allowedQuery));
+      const queryAst = JSON.parse(JSON.stringify(normalizedQuery));
+
+      // Remove or normalize value fields from both ASTs
+      const normalizeAst = (ast: any) => {
+        if (Array.isArray(ast)) {
+          ast.forEach(normalizeAst);
+        } else if (ast && typeof ast === "object") {
+          // Remove or normalize fields that contain specific values
+          if ("value" in ast) {
+            ast.value = "?";
+          }
+
+          Object.values(ast).forEach(normalizeAst);
         }
 
-        const normalizedQuery = parser.astify(normalizeSQL(sql));
-        
-        // Compare ASTs while ignoring specific values
-        const isCurrentAllowed = normalizedAllowlist?.some(allowedQuery => {
-            // Create deep copies to avoid modifying original ASTs
-            const allowedAst = JSON.parse(JSON.stringify(allowedQuery));
-            const queryAst = JSON.parse(JSON.stringify(normalizedQuery));
-            
-            // Remove or normalize value fields from both ASTs
-            const normalizeAst = (ast: any) => {
-                if (Array.isArray(ast)) {
-                    ast.forEach(normalizeAst);
-                } else if (ast && typeof ast === 'object') {
-                    // Remove or normalize fields that contain specific values
-                    if ('value' in ast) {
-                        ast.value = '?';
-                    }
-                    
-                    Object.values(ast).forEach(normalizeAst);
-                }
+        return ast;
+      };
 
-                return ast;
-            };
+      normalizeAst(allowedAst);
+      normalizeAst(queryAst);
 
-            normalizeAst(allowedAst);
-            normalizeAst(queryAst);
-            
-            return JSON.stringify(allowedAst) === JSON.stringify(queryAst);
-        });
+      return JSON.stringify(allowedAst) === JSON.stringify(queryAst);
+    });
 
-        if (!isCurrentAllowed) {
-            throw new Error("Query not allowed");
-        }
-
-        return true;
-    } catch (error: any) {
-        throw new Error(error?.message ?? 'Error');
+    if (!isCurrentAllowed) {
+      throw new Error("Query not allowed");
     }
+
+    return true;
+  } catch (error: any) {
+    throw new Error(error?.message ?? "Error");
+  }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,5 +1,5 @@
 import { StarbaseDBConfiguration } from "../handler";
-import { DataSource } from "../types";
+import { DataSource, QueryResult } from "../types";
 import sqlparser from "node-sql-parser";
 const parser = new sqlparser.Parser();
 
@@ -62,7 +62,7 @@ export async function beforeQueryCache(opts: {
   const result = await dataSource.rpc.executeQuery({
     sql: fetchCacheStatement,
     params: [sql],
-  });
+  }) as any[];
 
   if (result?.length) {
     const { timestamp, ttl, results } = result[0] as QueryResult;
@@ -115,7 +115,7 @@ export async function afterQueryCache(opts: {
     const exists = await dataSource.rpc.executeQuery({
       sql: "SELECT 1 FROM tmp_cache WHERE query = ? LIMIT 1",
       params: [sql],
-    });
+    }) as QueryResult[];
 
     const query = exists?.length
       ? {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,52 +1,79 @@
-import { DataSource, Source } from "../types";
-const parser = new (require('node-sql-parser').Parser)();
+import { StarbaseDBConfiguration } from "../handler";
+import { DataSource } from "../types";
+import sqlparser from "node-sql-parser";
+const parser = new sqlparser.Parser();
 
 function hasModifyingStatement(ast: any): boolean {
-    // Check if current node is a modifying statement
-    if (ast.type && ['insert', 'update', 'delete'].includes(ast.type.toLowerCase())) {
-        return true;
-    }
+  // Check if current node is a modifying statement
+  if (
+    ast.type &&
+    ["insert", "update", "delete"].includes(ast.type.toLowerCase())
+  ) {
+    return true;
+  }
 
-    // Recursively check all properties of the AST
-    for (const key in ast) {
-        if (typeof ast[key] === 'object' && ast[key] !== null) {
-            if (Array.isArray(ast[key])) {
-                if (ast[key].some(item => hasModifyingStatement(item))) {
-                    return true;
-                }
-            } else if (hasModifyingStatement(ast[key])) {
-                return true;
-            }
+  // Recursively check all properties of the AST
+  for (const key in ast) {
+    if (typeof ast[key] === "object" && ast[key] !== null) {
+      if (Array.isArray(ast[key])) {
+        if (ast[key].some((item) => hasModifyingStatement(item))) {
+          return true;
         }
+      } else if (hasModifyingStatement(ast[key])) {
+        return true;
+      }
     }
+  }
 
-    return false;
+  return false;
 }
 
-export async function beforeQueryCache(sql: string, params?: any[], dataSource?: DataSource, dialect?: string): Promise<any | null> {
-    // Currently we do not support caching queries that have dynamic parameters
-    if (params?.length) return null
-    if (dataSource?.source === Source.internal || !dataSource?.request.headers.has('X-Starbase-Cache')) return null
+export async function beforeQueryCache(opts: {
+  sql: string;
+  params?: unknown[];
+  dataSource: DataSource;
+}): Promise<unknown | null> {
+  const { sql, params = [], dataSource } = opts;
 
-    if (!dialect) dialect = 'sqlite'
-    if (dialect.toLowerCase() === 'postgres') dialect = 'postgresql'
+  // Currently we do not support caching queries that have dynamic parameters
+  if (params.length) {
+    return null;
+  }
 
-    let ast = parser.astify(sql, { database: dialect });
-    if (hasModifyingStatement(ast)) return null
-    
-    const fetchCacheStatement = `SELECT timestamp, ttl, query, results FROM tmp_cache WHERE query = ?`
-    const result = await dataSource.internalConnection?.durableObject.executeQuery(fetchCacheStatement, [sql], false) as any[];
+  // If it's an internal request, or cache is not enabled, return null.
+  if (dataSource.source === "internal" || !dataSource.cache) {
+    return null;
+  }
 
-    if (result?.length) {
-        const { timestamp, ttl, results } = result[0];
-        const expirationTime = new Date(timestamp).getTime() + (ttl * 1000);
-        
-        if (Date.now() < expirationTime) {
-            return JSON.parse(results)
-        }
+  const dialect =
+    dataSource.source === "external" ? dataSource.external!.dialect : "sqlite";
+
+  let ast = parser.astify(sql, { database: dialect });
+  if (hasModifyingStatement(ast)) return null;
+
+  const fetchCacheStatement = `SELECT timestamp, ttl, query, results FROM tmp_cache WHERE query = ?`;
+
+  type QueryResult = {
+    timestamp: string;
+    ttl: number;
+    results: string;
+  };
+
+  const result = await dataSource.rpc.executeQuery({
+    sql: fetchCacheStatement,
+    params: [sql],
+  });
+
+  if (result?.length) {
+    const { timestamp, ttl, results } = result[0] as QueryResult;
+    const expirationTime = new Date(timestamp).getTime() + ttl * 1000;
+
+    if (Date.now() < expirationTime) {
+      return JSON.parse(results);
     }
+  }
 
-    return null
+  return null;
 }
 
 // Serialized RPC arguemnts are limited to 1MiB in size at the moment for Cloudflare
@@ -55,36 +82,58 @@ export async function beforeQueryCache(sql: string, params?: any[], dataSource?:
 // to look into include using Cloudflare Cache but need to find a good way to cache the
 // response in a safe way for our use case. Another option is another service for queues
 // or another way to ingest it directly to the Durable Object.
-export async function afterQueryCache(sql: string, params: any[] | undefined, result: any, dataSource?: DataSource, dialect?: string) {
-    // Currently we do not support caching queries that have dynamic parameters
-    if (params?.length) return;
-    if (dataSource?.source === Source.internal || !dataSource?.request.headers.has('X-Starbase-Cache')) return null
+export async function afterQueryCache(opts: {
+  sql: string;
+  params: unknown[] | undefined;
+  result: unknown;
+  dataSource: DataSource;
+}) {
+  const { sql, params, result, dataSource } = opts;
 
-    try {
-        if (!dialect) dialect = 'sqlite'
-        if (dialect.toLowerCase() === 'postgres') dialect = 'postgresql'
+  // Currently we do not support caching queries that have dynamic parameters
+  if (params?.length) return;
 
-        let ast = parser.astify(sql, { database: dialect });
-        
-        // If any modifying query exists within our SQL statement then we shouldn't proceed
-        if (hasModifyingStatement(ast)) return;
+  // If it's an internal request, or cache is not enabled, return null.
+  if (dataSource.source === "internal" || !dataSource.cache) {
+    return null;
+  }
 
-        const timestamp = Date.now();
-        const results = JSON.stringify(result);
-        
-        const exists = await dataSource.internalConnection?.durableObject.executeQuery(
-            'SELECT 1 FROM tmp_cache WHERE query = ? LIMIT 1',
-            [sql],
-            false
-        ) as any[];
+  try {
+    const dialect =
+      dataSource.source === "external"
+        ? dataSource.external!.dialect
+        : "sqlite";
 
-        const query = exists?.length 
-            ? { sql: 'UPDATE tmp_cache SET timestamp = ?, results = ? WHERE query = ?', params: [timestamp, results, sql] }
-            : { sql: 'INSERT INTO tmp_cache (timestamp, ttl, query, results) VALUES (?, ?, ?, ?)', params: [timestamp, 60, sql, results] };
+    let ast = parser.astify(sql, { database: dialect });
 
-        await dataSource.internalConnection?.durableObject.executeQuery(query.sql, query.params, false);
-    } catch (error) {
-        console.error('Error in cache operation:', error);
-        return;
-    }
+    // If any modifying query exists within our SQL statement then we shouldn't proceed
+    if (hasModifyingStatement(ast)) return;
+
+    const timestamp = Date.now();
+    const results = JSON.stringify(result);
+
+    const exists = await dataSource.rpc.executeQuery({
+      sql: "SELECT 1 FROM tmp_cache WHERE query = ? LIMIT 1",
+      params: [sql],
+    });
+
+    const query = exists?.length
+      ? {
+          sql: "UPDATE tmp_cache SET timestamp = ?, results = ? WHERE query = ?",
+          params: [timestamp, results, sql],
+        }
+      : {
+          sql: "INSERT INTO tmp_cache (timestamp, ttl, query, results) VALUES (?, ?, ?, ?)",
+          // TODO: Make TTL configurable
+          params: [timestamp, 60, sql, results],
+        };
+
+    await dataSource.rpc.executeQuery({
+      sql: query.sql,
+      params: query.params,
+    });
+  } catch (error) {
+    console.error("Error in cache operation:", error);
+    return;
+  }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -124,8 +124,7 @@ export async function afterQueryCache(opts: {
         }
       : {
           sql: "INSERT INTO tmp_cache (timestamp, ttl, query, results) VALUES (?, ?, ?, ?)",
-          // TODO: Make TTL configurable
-          params: [timestamp, 60, sql, results],
+          params: [timestamp, dataSource.cacheTTL ?? 60, sql, results],
         };
 
     await dataSource.rpc.executeQuery({

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,7 +1,7 @@
 export const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Starbase-Source',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Starbase-Source, X-Data-Source',
     'Access-Control-Max-Age': '86400',
 };
 

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,16 +1,14 @@
 export const corsHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Starbase-Source, X-Data-Source',
-    'Access-Control-Max-Age': '86400',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Authorization, Content-Type, X-Starbase-Source, X-Data-Source",
+  "Access-Control-Max-Age": "86400",
 };
 
-export function corsPreflight(request: Request): Response | undefined {
-    // Handle OPTIONS preflight request first
-    if (request.method === 'OPTIONS') {
-        return new Response(null, {
-            status: 204,
-            headers: corsHeaders
-        });
-    }
+export function corsPreflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  });
 }

--- a/src/do.ts
+++ b/src/do.ts
@@ -1,17 +1,17 @@
 import { DurableObject } from "cloudflare:workers";
-import { OperationQueueItem } from "./operation";
-import { createResponse } from "./utils";
+// import { OperationQueueItem } from "./operation";
+// import { createResponse } from "./utils";
 
 export class StarbaseDBDurableObject extends DurableObject {
   // Durable storage for the SQL database
   public sql: SqlStorage;
   public storage: DurableObjectStorage;
 
-  // Queue of operations to be processed, with each operation containing a list of queries to be executed
-  private operationQueue: Array<OperationQueueItem> = [];
+  // // Queue of operations to be processed, with each operation containing a list of queries to be executed
+  // private operationQueue: Array<OperationQueueItem> = [];
 
-  // Flag to indicate if an operation is currently being processed
-  private processingOperation: { value: boolean } = { value: false };
+  // // Flag to indicate if an operation is currently being processed
+  // private processingOperation: { value: boolean } = { value: false };
 
   /**
    * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
@@ -64,42 +64,43 @@ export class StarbaseDBDurableObject extends DurableObject {
     };
   }
 
-  /**
-   * Execute a raw SQL query on the database, typically used for external requests
-   * from other service bindings (e.g. auth). This serves as an exposed function for
-   * other service bindings to query the database without having to have knowledge of
-   * the current operation queue or processing state.
-   *
-   * @param sql - The SQL query to execute.
-   * @param params - Optional parameters for the SQL query.
-   * @returns A response containing the query result or an error message.
-   */
-  private async executeExternalQuery(
-    sql: string,
-    params: any[] | undefined
-  ): Promise<any> {
-    try {
-      const queries = [{ sql, params }];
-      const response = await this.enqueueOperation(
-        queries,
-        false,
-        false,
-        this.operationQueue,
-        () =>
-          this.processNextOperation(
-            this.sql,
-            this.operationQueue,
-            this.ctx,
-            this.processingOperation
-          )
-      );
+  // TODO: Hiding for now as it's not used in the current implementation
+  // /**
+  //  * Execute a raw SQL query on the database, typically used for external requests
+  //  * from other service bindings (e.g. auth). This serves as an exposed function for
+  //  * other service bindings to query the database without having to have knowledge of
+  //  * the current operation queue or processing state.
+  //  *
+  //  * @param sql - The SQL query to execute.
+  //  * @param params - Optional parameters for the SQL query.
+  //  * @returns A response containing the query result or an error message.
+  //  */
+  // private async executeExternalQuery(
+  //   sql: string,
+  //   params: any[] | undefined
+  // ): Promise<any> {
+  //   try {
+  //     const queries = [{ sql, params }];
+  //     const response = await this.enqueueOperation(
+  //       queries,
+  //       false,
+  //       false,
+  //       this.operationQueue,
+  //       () =>
+  //         this.processNextOperation(
+  //           this.sql,
+  //           this.operationQueue,
+  //           this.ctx,
+  //           this.processingOperation
+  //         )
+  //     );
 
-      return response;
-    } catch (error: any) {
-      console.error("Execute External Query Error:", error);
-      return null;
-    }
-  }
+  //     return response;
+  //   } catch (error: any) {
+  //     console.error("Execute External Query Error:", error);
+  //     return null;
+  //   }
+  // }
 
   public async executeRawQuery<
     T extends Record<string, SqlStorageValue> = Record<string, SqlStorageValue>
@@ -130,8 +131,17 @@ export class StarbaseDBDurableObject extends DurableObject {
     }
   }
 
-  public async executeQuery(opts: { sql: string; params?: unknown[] }) {
+  public async executeQuery(opts: {
+    sql: string;
+    params?: unknown[];
+    isRaw?: boolean;
+  }) {
     const result = await this.executeRawQuery(opts);
+
+    if (opts.isRaw) {
+      return result;
+    }
+
     return result.cursor.toArray();
   }
 
@@ -145,7 +155,7 @@ export class StarbaseDBDurableObject extends DurableObject {
       try {
         for (const queryObj of queries) {
           const { sql, params } = queryObj;
-          const result = this.executeQuery({ sql, params });
+          const result = this.executeQuery({ sql, params, isRaw });
           results.push(result);
         }
 
@@ -157,90 +167,92 @@ export class StarbaseDBDurableObject extends DurableObject {
     });
   }
 
-  enqueueOperation(
-    queries: { sql: string; params?: any[] }[],
-    isTransaction: boolean,
-    isRaw: boolean,
-    operationQueue: any[],
-    processNextOperation: () => Promise<void>
-  ): Promise<{ result?: any; error?: string | undefined; status: number }> {
-    const MAX_WAIT_TIME = 25000;
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(createResponse(undefined, "Operation timed out.", 503));
-      }, MAX_WAIT_TIME);
+  // TODO: Hiding for now as it's not used in the current implementation
+  // private enqueueOperation(
+  //   queries: { sql: string; params?: any[] }[],
+  //   isTransaction: boolean,
+  //   isRaw: boolean,
+  //   operationQueue: any[],
+  //   processNextOperation: () => Promise<void>
+  // ): Promise<{ result?: any; error?: string | undefined; status: number }> {
+  //   const MAX_WAIT_TIME = 25000;
+  //   return new Promise((resolve, reject) => {
+  //     const timeout = setTimeout(() => {
+  //       reject(createResponse(undefined, "Operation timed out.", 503));
+  //     }, MAX_WAIT_TIME);
 
-      operationQueue.push({
-        queries,
-        isTransaction,
-        isRaw,
-        resolve: (value: any) => {
-          clearTimeout(timeout);
+  //     operationQueue.push({
+  //       queries,
+  //       isTransaction,
+  //       isRaw,
+  //       resolve: (value: any) => {
+  //         clearTimeout(timeout);
 
-          resolve({
-            result: value,
-            error: undefined,
-            status: 200,
-          });
-        },
-        reject: (reason?: any) => {
-          clearTimeout(timeout);
+  //         resolve({
+  //           result: value,
+  //           error: undefined,
+  //           status: 200,
+  //         });
+  //       },
+  //       reject: (reason?: any) => {
+  //         clearTimeout(timeout);
 
-          reject({
-            result: undefined,
-            error: reason ?? "Operation failed.",
-            status: 500,
-          });
-        },
-      });
+  //         reject({
+  //           result: undefined,
+  //           error: reason ?? "Operation failed.",
+  //           status: 500,
+  //         });
+  //       },
+  //     });
 
-      processNextOperation().catch((err) => {
-        console.error("Error processing operation queue:", err);
-      });
-    });
-  }
+  //     processNextOperation().catch((err) => {
+  //       console.error("Error processing operation queue:", err);
+  //     });
+  //   });
+  // }
 
-  private async processNextOperation(
-    sqlInstance: any,
-    operationQueue: OperationQueueItem[],
-    ctx: any,
-    processingOperation: { value: boolean }
-  ) {
-    if (processingOperation.value) {
-      // Already processing an operation
-      return;
-    }
+  // TODO: Hiding for now as it's not used in the current implementation
+  // private async processNextOperation(
+  //   sqlInstance: any,
+  //   operationQueue: OperationQueueItem[],
+  //   ctx: any,
+  //   processingOperation: { value: boolean }
+  // ) {
+  //   if (processingOperation.value) {
+  //     // Already processing an operation
+  //     return;
+  //   }
 
-    if (operationQueue.length === 0) {
-      // No operations remaining to process
-      return;
-    }
+  //   if (operationQueue.length === 0) {
+  //     // No operations remaining to process
+  //     return;
+  //   }
 
-    processingOperation.value = true;
-    const { queries, isTransaction, isRaw, resolve, reject } =
-      operationQueue.shift()!;
+  //   processingOperation.value = true;
+  //   const { queries, isTransaction, isRaw, resolve, reject } =
+  //     operationQueue.shift()!;
 
-    try {
-      let result;
+  //   try {
+  //     let result;
 
-      if (isTransaction) {
-        result = await this.executeTransaction(queries, isRaw);
-      } else {
-        const { sql, params } = queries[0];
-        result = this.executeQuery({ sql, params });
-      }
+  //     if (isTransaction) {
+  //       result = await this.executeTransaction(queries, isRaw);
+  //     } else {
+  //       const { sql, params } = queries[0];
+  //       result = this.executeQuery({ sql, params });
+  //     }
 
-      resolve(result);
-    } catch (error: any) {
-      reject(error.message || "Operation failed.");
-    } finally {
-      processingOperation.value = false;
-      await this.processNextOperation(
-        sqlInstance,
-        operationQueue,
-        ctx,
-        processingOperation
-      );
-    }
-  }
+  //     resolve(result);
+  //   } catch (error: any) {
+  //     reject(error.message || "Operation failed.");
+  //   } finally {
+  //     processingOperation.value = false;
+  //     await this.processNextOperation(
+  //       sqlInstance,
+  //       operationQueue,
+  //       ctx,
+  //       processingOperation
+  //     );
+  //   }
+  // }
 }

--- a/src/do.ts
+++ b/src/do.ts
@@ -1,47 +1,47 @@
 import { DurableObject } from "cloudflare:workers";
-import { OperationQueueItem, QueryResponse } from "./operation";
+import { OperationQueueItem } from "./operation";
 import { createResponse } from "./utils";
 
-export class DatabaseDurableObject extends DurableObject {
-    // Durable storage for the SQL database
-    public sql: SqlStorage;
-    public storage: DurableObjectStorage;
+export class StarbaseDBDurableObject extends DurableObject {
+  // Durable storage for the SQL database
+  public sql: SqlStorage;
+  public storage: DurableObjectStorage;
 
-    // Queue of operations to be processed, with each operation containing a list of queries to be executed
-    private operationQueue: Array<OperationQueueItem> = [];
+  // Queue of operations to be processed, with each operation containing a list of queries to be executed
+  private operationQueue: Array<OperationQueueItem> = [];
 
-    // Flag to indicate if an operation is currently being processed
-    private processingOperation: { value: boolean } = { value: false };
+  // Flag to indicate if an operation is currently being processed
+  private processingOperation: { value: boolean } = { value: false };
 
-	/**
-	 * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
-	 * 	`DurableObjectStub::get` for a given identifier (no-op constructors can be omitted)
-	 *
-	 * @param ctx - The interface for interacting with Durable Object state
-	 * @param env - The interface to reference bindings declared in wrangler.toml
-	 */
-    constructor(ctx: DurableObjectState, env: Env) {
-        super(ctx, env);
-        this.sql = ctx.storage.sql;
-        this.storage = ctx.storage;
+  /**
+   * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
+   * 	`DurableObjectStub::get` for a given identifier (no-op constructors can be omitted)
+   *
+   * @param ctx - The interface for interacting with Durable Object state
+   * @param env - The interface to reference bindings declared in wrangler.toml
+   */
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    this.storage = ctx.storage;
 
-        // Install default necessary `tmp_` tables for various features here.
-        const cacheStatement = `
+    // Install default necessary `tmp_` tables for various features here.
+    const cacheStatement = `
         CREATE TABLE IF NOT EXISTS tmp_cache (
             "id" INTEGER PRIMARY KEY AUTOINCREMENT,
             "timestamp" REAL NOT NULL,
             "ttl" INTEGER NOT NULL,
             "query" TEXT UNIQUE NOT NULL,
             "results" TEXT
-        );`
+        );`;
 
-        const allowlistStatement = `
+    const allowlistStatement = `
         CREATE TABLE IF NOT EXISTS tmp_allowlist_queries (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             sql_statement TEXT NOT NULL
-        )`
+        )`;
 
-        const rlsStatement = `
+    const rlsStatement = `
         CREATE TABLE IF NOT EXISTS tmp_rls_policies (
             "id" INTEGER PRIMARY KEY AUTOINCREMENT,
             "actions" TEXT NOT NULL CHECK(actions IN ('SELECT', 'UPDATE', 'INSERT', 'DELETE')),
@@ -51,170 +51,196 @@ export class DatabaseDurableObject extends DurableObject {
             "value" TEXT NOT NULL,
             "value_type" TEXT NOT NULL DEFAULT 'string',
             "operator" TEXT DEFAULT '='
-        )`
+        )`;
 
-        this.executeQuery(cacheStatement, undefined, false)
-        this.executeQuery(allowlistStatement, undefined, false)
-        this.executeQuery(rlsStatement, undefined, false)
+    this.executeQuery({ sql: cacheStatement });
+    this.executeQuery({ sql: allowlistStatement });
+    this.executeQuery({ sql: rlsStatement });
+  }
+
+  init() {
+    return {
+      executeQuery: this.executeQuery.bind(this),
+    };
+  }
+
+  /**
+   * Execute a raw SQL query on the database, typically used for external requests
+   * from other service bindings (e.g. auth). This serves as an exposed function for
+   * other service bindings to query the database without having to have knowledge of
+   * the current operation queue or processing state.
+   *
+   * @param sql - The SQL query to execute.
+   * @param params - Optional parameters for the SQL query.
+   * @returns A response containing the query result or an error message.
+   */
+  private async executeExternalQuery(
+    sql: string,
+    params: any[] | undefined
+  ): Promise<any> {
+    try {
+      const queries = [{ sql, params }];
+      const response = await this.enqueueOperation(
+        queries,
+        false,
+        false,
+        this.operationQueue,
+        () =>
+          this.processNextOperation(
+            this.sql,
+            this.operationQueue,
+            this.ctx,
+            this.processingOperation
+          )
+      );
+
+      return response;
+    } catch (error: any) {
+      console.error("Execute External Query Error:", error);
+      return null;
     }
+  }
 
-    /**
-     * Execute a raw SQL query on the database, typically used for external requests
-     * from other service bindings (e.g. auth). This serves as an exposed function for
-     * other service bindings to query the database without having to have knowledge of
-     * the current operation queue or processing state.
-     * 
-     * @param sql - The SQL query to execute.
-     * @param params - Optional parameters for the SQL query.
-     * @returns A response containing the query result or an error message.
-     */
-    async executeExternalQuery(sql: string, params: any[] | undefined): Promise<any> {
-        try {
-            const queries = [{ sql, params }];
-            const response = await this.enqueueOperation(
-                queries,
-                false,
-                false,
-                this.operationQueue,
-                () => this.processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-            );
+  public async executeRawQuery<
+    T extends Record<string, SqlStorageValue> = Record<string, SqlStorageValue>
+  >(opts: { sql: string; params?: unknown[] }) {
+    const { sql, params } = opts;
 
-            return response;
-        } catch (error: any) {
-            console.error('Execute External Query Error:', error);
-            return null;
-        }
+    try {
+      let cursor;
+
+      if (params && params.length) {
+        cursor = this.sql.exec<T>(sql, ...params);
+      } else {
+        cursor = this.sql.exec<T>(sql);
+      }
+
+      return {
+        cursor,
+        columns: cursor.columnNames,
+        rows: Array.from(cursor.raw()),
+        meta: {
+          rows_read: cursor.rowsRead,
+          rows_written: cursor.rowsWritten,
+        },
+      };
+    } catch (error) {
+      console.error("SQL Execution Error:", error);
+      throw error;
     }
+  }
 
-    public executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse {
-        try {
-            let cursor;
-            
-            if (params && params.length) {
-                cursor = this.sql.exec(sql, ...params);
-            } else {
-                cursor = this.sql.exec(sql);
-            }
+  public async executeQuery(opts: { sql: string; params?: unknown[] }) {
+    const result = await this.executeRawQuery(opts);
+    return result.cursor.toArray();
+  }
 
-            let result;
+  public executeTransaction(
+    queries: { sql: string; params?: unknown[] }[],
+    isRaw: boolean
+  ): unknown[] {
+    return this.storage.transactionSync(() => {
+      const results = [];
 
-            if (isRaw) {
-                result = {
-                    columns: cursor.columnNames,
-                    rows: Array.from(cursor.raw()),
-                    meta: {
-                        rows_read: cursor.rowsRead,
-                        rows_written: cursor.rowsWritten,
-                    },
-                };        
-            } else {
-                result = cursor.toArray();
-            }
-
-            return result;
-        } catch (error) {
-            console.error('SQL Execution Error:', error);
-            throw error;
-        }
-    }
-
-    public executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[] {
-        return this.storage.transactionSync(() => {
-            const results = [];
-
-            try {
-                for (const queryObj of queries) {
-                    const { sql, params } = queryObj;
-                    const result = this.executeQuery(sql, params, isRaw);
-                    results.push(result);
-                }
-
-                return results;
-            } catch (error) {
-                console.error('Transaction Execution Error:', error);
-                throw error;
-            }
-        });
-    }
-
-    enqueueOperation(
-        queries: { sql: string; params?: any[] }[],
-        isTransaction: boolean,
-        isRaw: boolean,
-        operationQueue: any[],
-        processNextOperation: () => Promise<void>
-    ): Promise<{ result?: any, error?: string | undefined, status: number }> {
-        const MAX_WAIT_TIME = 25000;
-        return new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                reject(createResponse(undefined, 'Operation timed out.', 503));
-            }, MAX_WAIT_TIME);
-
-            operationQueue.push({
-                queries,
-                isTransaction,
-                isRaw,
-                resolve: (value: any) => {
-                    clearTimeout(timeout);
-
-                    resolve({
-                        result: value,
-                        error: undefined,
-                        status: 200
-                    })
-                },
-                reject: (reason?: any) => {
-                    clearTimeout(timeout);
-
-                    reject({
-                        result: undefined,
-                        error: reason ?? 'Operation failed.',
-                        status: 500
-                    })
-                }
-            });
-
-            processNextOperation().catch((err) => {
-                console.error('Error processing operation queue:', err);
-            });
-        });
-    }
-
-    async processNextOperation(
-        sqlInstance: any,
-        operationQueue: OperationQueueItem[],
-        ctx: any,
-        processingOperation: { value: boolean }
-    ) {
-        if (processingOperation.value) {
-            // Already processing an operation
-            return;
+      try {
+        for (const queryObj of queries) {
+          const { sql, params } = queryObj;
+          const result = this.executeQuery({ sql, params });
+          results.push(result);
         }
 
-        if (operationQueue.length === 0) {
-            // No operations remaining to process
-            return;
-        }
+        return results;
+      } catch (error) {
+        console.error("Transaction Execution Error:", error);
+        throw error;
+      }
+    });
+  }
 
-        processingOperation.value = true;
-        const { queries, isTransaction, isRaw, resolve, reject } = operationQueue.shift()!;
+  enqueueOperation(
+    queries: { sql: string; params?: any[] }[],
+    isTransaction: boolean,
+    isRaw: boolean,
+    operationQueue: any[],
+    processNextOperation: () => Promise<void>
+  ): Promise<{ result?: any; error?: string | undefined; status: number }> {
+    const MAX_WAIT_TIME = 25000;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(createResponse(undefined, "Operation timed out.", 503));
+      }, MAX_WAIT_TIME);
 
-        try {
-            let result;
+      operationQueue.push({
+        queries,
+        isTransaction,
+        isRaw,
+        resolve: (value: any) => {
+          clearTimeout(timeout);
 
-            if (isTransaction) {
-                result = await this.executeTransaction(queries, isRaw);
-            } else {
-                const { sql, params } = queries[0];
-                result = this.executeQuery(sql, params, isRaw);
-            }
+          resolve({
+            result: value,
+            error: undefined,
+            status: 200,
+          });
+        },
+        reject: (reason?: any) => {
+          clearTimeout(timeout);
 
-            resolve(result);
-        } catch (error: any) {
-            reject(error.message || 'Operation failed.');
-        } finally {
-            processingOperation.value = false;
-            await this.processNextOperation(sqlInstance, operationQueue, ctx, processingOperation);
-        }
+          reject({
+            result: undefined,
+            error: reason ?? "Operation failed.",
+            status: 500,
+          });
+        },
+      });
+
+      processNextOperation().catch((err) => {
+        console.error("Error processing operation queue:", err);
+      });
+    });
+  }
+
+  private async processNextOperation(
+    sqlInstance: any,
+    operationQueue: OperationQueueItem[],
+    ctx: any,
+    processingOperation: { value: boolean }
+  ) {
+    if (processingOperation.value) {
+      // Already processing an operation
+      return;
     }
+
+    if (operationQueue.length === 0) {
+      // No operations remaining to process
+      return;
+    }
+
+    processingOperation.value = true;
+    const { queries, isTransaction, isRaw, resolve, reject } =
+      operationQueue.shift()!;
+
+    try {
+      let result;
+
+      if (isTransaction) {
+        result = await this.executeTransaction(queries, isRaw);
+      } else {
+        const { sql, params } = queries[0];
+        result = this.executeQuery({ sql, params });
+      }
+
+      resolve(result);
+    } catch (error: any) {
+      reject(error.message || "Operation failed.");
+    } finally {
+      processingOperation.value = false;
+      await this.processNextOperation(
+        sqlInstance,
+        operationQueue,
+        ctx,
+        processingOperation
+      );
+    }
+  }
 }

--- a/src/export/csv.ts
+++ b/src/export/csv.ts
@@ -1,13 +1,15 @@
 import { getTableData, createExportResponse } from './index';
 import { createResponse } from '../utils';
 import { DataSource } from '../types';
+import { StarbaseDBConfiguration } from '../handler';
 
 export async function exportTableToCsvRoute(
     tableName: string,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        const data = await getTableData(tableName, dataSource);
+        const data = await getTableData(tableName, dataSource, config);
 
         if (data === null) {
             return createResponse(undefined, `Table '${tableName}' does not exist.`, 404);

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -1,13 +1,15 @@
 import { executeOperation } from '.';
+import { StarbaseDBConfiguration } from '../handler';
 import { DataSource } from '../types';
 import { createResponse } from '../utils';
 
 export async function dumpDatabaseRoute(
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
         // Get all table names
-        const tablesResult = await executeOperation([{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }], dataSource)
+        const tablesResult = await executeOperation([{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }], dataSource, config)
         
         const tables = tablesResult.map((row: any) => row.name);
         let dumpContent = "SQLite format 3\0";  // SQLite file header
@@ -15,7 +17,7 @@ export async function dumpDatabaseRoute(
         // Iterate through all tables
         for (const table of tables) {
             // Get table schema
-            const schemaResult = await executeOperation([{ sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';` }], dataSource)
+            const schemaResult = await executeOperation([{ sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';` }], dataSource, config)
 
             if (schemaResult.length) {
                 const schema = schemaResult[0].sql;
@@ -23,7 +25,7 @@ export async function dumpDatabaseRoute(
             }
 
             // Get table data
-            const dataResult = await executeOperation([{ sql: `SELECT * FROM ${table};` }], dataSource)
+            const dataResult = await executeOperation([{ sql: `SELECT * FROM ${table};` }], dataSource, config)
 
             for (const row of dataResult) {
                 const values = Object.values(row).map(value => 

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,25 +1,32 @@
 import { DataSource } from "../types";
 import { executeTransaction } from "../operation";
+import { StarbaseDBConfiguration } from "../handler";
 
-export async function executeOperation(queries: { sql: string, params?: any[] }[], dataSource: DataSource): Promise<any> {
-    const results: any[] = (await executeTransaction(queries, false, dataSource)) as any[];
+export async function executeOperation(queries: { sql: string, params?: any[] }[], dataSource: DataSource, config: StarbaseDBConfiguration): Promise<any> {
+    const results: any[] = (await executeTransaction({
+        queries,
+        isRaw: false,
+        dataSource,
+        config
+    })) as any[];
     return results?.length > 0 ? results[0] : undefined;
 }
 
 export async function getTableData(
     tableName: string,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<any[] | null> {
     try {
         // Verify if the table exists
-        const tableExistsResult = await executeOperation([{ sql: `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`, params: [tableName] }], dataSource)
+        const tableExistsResult = await executeOperation([{ sql: `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`, params: [tableName] }], dataSource, config)
 
         if (tableExistsResult.length === 0) {
             return null;
         }
 
         // Get table data
-        const dataResult = await executeOperation([{ sql: `SELECT * FROM ${tableName};` }], dataSource)
+        const dataResult = await executeOperation([{ sql: `SELECT * FROM ${tableName};` }], dataSource, config)
         return dataResult;
     } catch (error: any) {
         console.error('Table Data Fetch Error:', error);

--- a/src/export/json.ts
+++ b/src/export/json.ts
@@ -1,13 +1,15 @@
 import { getTableData, createExportResponse } from './index';
 import { createResponse } from '../utils';
 import { DataSource } from '../types';
+import { StarbaseDBConfiguration } from '../handler';
 
 export async function exportTableToJsonRoute(
     tableName: string,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        const data = await getTableData(tableName, dataSource);
+        const data = await getTableData(tableName, dataSource, config);
 
         if (data === null) {
             return createResponse(undefined, `Table '${tableName}' does not exist.`, 404);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -155,7 +155,7 @@ export class StarbaseDB {
 
     if (this.getFeature("export")) {
       app.get("/export/dump", this.isInternalSource, async () => {
-        return dumpDatabaseRoute(this.dataSource);
+        return dumpDatabaseRoute(this.dataSource, this.config);
       });
 
       app.get(
@@ -164,7 +164,7 @@ export class StarbaseDB {
         this.hasTableName,
         async (c) => {
           const tableName = c.req.valid("param").tableName;
-          return exportTableToJsonRoute(tableName, this.dataSource);
+          return exportTableToJsonRoute(tableName, this.dataSource, this.config);
         }
       );
 
@@ -174,14 +174,14 @@ export class StarbaseDB {
         this.hasTableName,
         async (c) => {
           const tableName = c.req.valid("param").tableName;
-          return exportTableToCsvRoute(tableName, this.dataSource);
+          return exportTableToCsvRoute(tableName, this.dataSource, this.config);
         }
       );
     }
 
     if (this.getFeature("import")) {
       app.post("/import/dump", this.isInternalSource, async (c) => {
-        return importDumpRoute(c.req.raw, this.dataSource);
+        return importDumpRoute(c.req.raw, this.dataSource, this.config);
       });
 
       app.post(
@@ -190,7 +190,7 @@ export class StarbaseDB {
         this.hasTableName,
         async (c) => {
           const tableName = c.req.valid("param").tableName;
-          return importTableFromJsonRoute(tableName, request, this.dataSource);
+          return importTableFromJsonRoute(tableName, request, this.dataSource, this.config);
         }
       );
 
@@ -200,7 +200,7 @@ export class StarbaseDB {
         this.hasTableName,
         async (c) => {
           const tableName = c.req.valid("param").tableName;
-          return importTableFromCsvRoute(tableName, request, this.dataSource);
+          return importTableFromCsvRoute(tableName, request, this.dataSource, this.config);
         }
       );
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,91 +1,117 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { createMiddleware } from "hono/factory";
 import { validator } from "hono/validator";
 
 import { DataSource, Source } from "./types";
 import { LiteREST } from "./literest";
-import { executeQuery, executeTransaction } from "./operation";
+// import { executeQuery, executeTransaction } from "./operation";
 import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";
-import { handleApiRequest } from "./api";
-import { dumpDatabaseRoute } from "./export/dump";
-import { exportTableToJsonRoute } from "./export/json";
-import { exportTableToCsvRoute } from "./export/csv";
-import { importDumpRoute } from "./import/dump";
-import { importTableFromJsonRoute } from "./import/json";
-import { importTableFromCsvRoute } from "./import/csv";
+// import { handleApiRequest } from "./api";
+// import { dumpDatabaseRoute } from "./export/dump";
+// import { exportTableToJsonRoute } from "./export/json";
+// import { exportTableToCsvRoute } from "./export/csv";
+// import { importDumpRoute } from "./import/dump";
+// import { importTableFromJsonRoute } from "./import/json";
+// import { importTableFromCsvRoute } from "./import/csv";
 
-export interface HandlerConfig {
-  adminAuthorizationToken: string;
-  outerbaseApiKey?: string;
-  enableAllowlist?: boolean;
-  enableRls?: boolean;
+// export interface HandlerConfig {
+//   adminAuthorizationToken: string;
+//   outerbaseApiKey?: string;
+//   enableAllowlist?: boolean;
+//   enableRls?: boolean;
 
-  externalDbType?: string;
+//   externalDbType?: string;
 
-  externalDbHost?: string;
-  externalDbPort?: number;
-  externalDbUser?: string;
-  externalDbPassword?: string;
-  externalDbName?: string;
-  externalDbDefaultSchema?: string;
+//   externalDbHost?: string;
+//   externalDbPort?: number;
+//   externalDbUser?: string;
+//   externalDbPassword?: string;
+//   externalDbName?: string;
+//   externalDbDefaultSchema?: string;
 
-  externalDbMongodbUri?: string;
+//   externalDbMongodbUri?: string;
 
-  externalDbTursoUri?: string;
-  externalDbTursoToken?: string;
+//   externalDbTursoUri?: string;
+//   externalDbTursoToken?: string;
 
-  externalDbCloudflareApiKey?: string;
-  externalDbCloudflareAccountId?: string;
-  externalDbCloudflareDatabaseId?: string;
+//   externalDbCloudflareApiKey?: string;
+//   externalDbCloudflareAccountId?: string;
+//   externalDbCloudflareDatabaseId?: string;
 
-  externalDbStarbaseUri?: string;
-  externalDbStarbaseToken?: string;
+//   externalDbStarbaseUri?: string;
+//   externalDbStarbaseToken?: string;
+// }
+
+export interface StarbaseDBConfiguration {
+  role: "admin" | "user";
+  features?: {
+    allowlist?: boolean;
+    rls?: boolean;
+    studio?: boolean;
+    rest?: boolean;
+    websocket?: boolean;
+    export?: boolean;
+    import?: boolean;
+  };
 }
 
-export class Handler {
+export class StarbaseDB {
   private dataSource: DataSource;
-  private config: HandlerConfig;
+  private config: StarbaseDBConfiguration;
   private liteREST: LiteREST;
 
-  constructor(options: { dataSource: DataSource; config: HandlerConfig }) {
+  constructor(options: {
+    dataSource: DataSource;
+    config: StarbaseDBConfiguration;
+  }) {
     this.dataSource = options.dataSource;
     this.config = options.config;
     this.liteREST = new LiteREST(this.dataSource, this.config);
   }
 
-  private get isInternalSource() {
-    return createMiddleware(async (_, next) => {
-      if (this.dataSource.source !== Source.internal) {
-        return createResponse(
-          undefined,
-          "Function is only available for internal data source.",
-          400
-        );
-      }
+  // private get isInternalSource() {
+  //   return createMiddleware(async (_, next) => {
+  //     if (this.dataSource.source !== Source.internal) {
+  //       return createResponse(
+  //         undefined,
+  //         "Function is only available for internal data source.",
+  //         400
+  //       );
+  //     }
 
-      return next();
-    });
-  }
+  //     return next();
+  //   });
+  // }
 
-  private get hasTableName() {
-    return validator("param", (params) => {
-      const tableName = params["tableName"];
+  // private get hasTableName() {
+  //   return validator("param", (params) => {
+  //     const tableName = params["tableName"];
 
-      if (!tableName) {
-        return createResponse(undefined, "Table name is required", 400);
-      }
+  //     if (!tableName) {
+  //       return createResponse(undefined, "Table name is required", 400);
+  //     }
 
-      return { tableName };
-    });
+  //     return { tableName };
+  //   });
+  // }
+
+  private getFeature(
+    key: keyof NonNullable<StarbaseDBConfiguration["features"]>,
+    defaultValue = true
+  ): boolean {
+    return this.config.features?.[key] ?? !!defaultValue;
   }
 
   public async handle(request: Request): Promise<Response> {
     const app = new Hono();
 
+    // General 404 not found handler
     app.notFound(() => {
       return createResponse(undefined, "Not found", 404);
     });
 
+    // Thrown error handler
     app.onError((error) => {
       return createResponse(
         undefined,
@@ -94,139 +120,160 @@ export class Handler {
       );
     });
 
-    app.all("/socket", async () => this.clientConnected());
+    // Allow CORS for all routes.
+    app.use(
+      cors({
+        origin: "*",
+        allowMethods: ["GET", "POST", "OPTIONS"],
+        allowHeaders: [
+          "Authorization",
+          "Content-Type",
+          "X-Starbase-Source",
+          "X-Data-Source",
+        ],
+        maxAge: 86400,
+      })
+    );
+
+    if (this.getFeature("websocket")) {
+      app.all("/socket", async () => this.clientConnected());
+    }
 
     app.post("/query/raw", async (c) => this.queryRoute(c.req.raw, true));
     app.post("/query", async (c) => this.queryRoute(c.req.raw, false));
 
-    app.all("/rest/*", async (c) => {
-      return this.liteREST.handleRequest(c.req.raw);
-    });
+    if (this.getFeature("rest")) {
+      app.all("/rest/*", async (c) => {
+        return this.liteREST.handleRequest(c.req.raw);
+      });
+    }
 
-    app.get("/export/dump", this.isInternalSource, async () => {
-      return dumpDatabaseRoute(this.dataSource);
-    });
+    if (this.getFeature("export")) {
+      app.get("/export/dump", this.isInternalSource, async () => {
+        return dumpDatabaseRoute(this.dataSource);
+      });
 
-    app.get(
-      "/export/json/:tableName",
-      this.isInternalSource,
-      this.hasTableName,
-      async (c) => {
-        const tableName = c.req.valid("param").tableName;
-        return exportTableToJsonRoute(tableName, this.dataSource);
-      }
-    );
+      app.get(
+        "/export/json/:tableName",
+        this.isInternalSource,
+        this.hasTableName,
+        async (c) => {
+          const tableName = c.req.valid("param").tableName;
+          return exportTableToJsonRoute(tableName, this.dataSource);
+        }
+      );
 
-    app.get(
-      "/export/csv/:tableName",
-      this.isInternalSource,
-      this.hasTableName,
-      async (c) => {
-        const tableName = c.req.valid("param").tableName;
-        return exportTableToCsvRoute(tableName, this.dataSource);
-      }
-    );
+      app.get(
+        "/export/csv/:tableName",
+        this.isInternalSource,
+        this.hasTableName,
+        async (c) => {
+          const tableName = c.req.valid("param").tableName;
+          return exportTableToCsvRoute(tableName, this.dataSource);
+        }
+      );
+    }
 
-    app.post("/import/dump", this.isInternalSource, async (c) => {
-      return importDumpRoute(c.req.raw, this.dataSource);
-    });
+    if (this.getFeature("import")) {
+      app.post("/import/dump", this.isInternalSource, async (c) => {
+        return importDumpRoute(c.req.raw, this.dataSource);
+      });
 
-    app.post(
-      "/import/json/:tableName",
-      this.isInternalSource,
-      this.hasTableName,
-      async (c) => {
-        const tableName = c.req.valid("param").tableName;
-        return importTableFromJsonRoute(tableName, request, this.dataSource);
-      }
-    );
+      app.post(
+        "/import/json/:tableName",
+        this.isInternalSource,
+        this.hasTableName,
+        async (c) => {
+          const tableName = c.req.valid("param").tableName;
+          return importTableFromJsonRoute(tableName, request, this.dataSource);
+        }
+      );
 
-    app.post(
-      "/import/csv/:tableName",
-      this.isInternalSource,
-      this.hasTableName,
-      async (c) => {
-        const tableName = c.req.valid("param").tableName;
-        return importTableFromCsvRoute(tableName, request, this.dataSource);
-      }
-    );
-
-    app.all("/api/*", async (c) => handleApiRequest(c.req.raw));
+      app.post(
+        "/import/csv/:tableName",
+        this.isInternalSource,
+        this.hasTableName,
+        async (c) => {
+          const tableName = c.req.valid("param").tableName;
+          return importTableFromCsvRoute(tableName, request, this.dataSource);
+        }
+      );
+    }
 
     return createResponse(undefined, "Unknown operation", 400);
   }
 
-  async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
-    try {
-      const contentType = request.headers.get("Content-Type") || "";
-      if (!contentType.includes("application/json")) {
-        return createResponse(
-          undefined,
-          "Content-Type must be application/json.",
-          400
-        );
-      }
+  // async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
+  //   try {
+  //     const contentType = request.headers.get("Content-Type") || "";
+  //     if (!contentType.includes("application/json")) {
+  //       return createResponse(
+  //         undefined,
+  //         "Content-Type must be application/json.",
+  //         400
+  //       );
+  //     }
 
-      const { sql, params, transaction } =
-        (await request.json()) as QueryRequest & QueryTransactionRequest;
+  //     const { sql, params, transaction } =
+  //       (await request.json()) as QueryRequest & QueryTransactionRequest;
 
-      if (Array.isArray(transaction) && transaction.length) {
-        const queries = transaction.map((queryObj: any) => {
-          const { sql, params } = queryObj;
+  //     if (Array.isArray(transaction) && transaction.length) {
+  //       const queries = transaction.map((queryObj: any) => {
+  //         const { sql, params } = queryObj;
 
-          if (typeof sql !== "string" || !sql.trim()) {
-            throw new Error('Invalid or empty "sql" field in transaction.');
-          } else if (
-            params !== undefined &&
-            !Array.isArray(params) &&
-            typeof params !== "object"
-          ) {
-            throw new Error(
-              'Invalid "params" field in transaction. Must be an array or object.'
-            );
-          }
+  //         if (typeof sql !== "string" || !sql.trim()) {
+  //           throw new Error('Invalid or empty "sql" field in transaction.');
+  //         } else if (
+  //           params !== undefined &&
+  //           !Array.isArray(params) &&
+  //           typeof params !== "object"
+  //         ) {
+  //           throw new Error(
+  //             'Invalid "params" field in transaction. Must be an array or object.'
+  //           );
+  //         }
 
-          return { sql, params };
-        });
+  //         return { sql, params };
+  //       });
 
-        const response = await executeTransaction(
-          queries,
-          isRaw,
-          this.dataSource,
-          this.config
-        );
-        return createResponse(response, undefined, 200);
-      } else if (typeof sql !== "string" || !sql.trim()) {
-        return createResponse(undefined, 'Invalid or empty "sql" field.', 400);
-      } else if (
-        params !== undefined &&
-        !Array.isArray(params) &&
-        typeof params !== "object"
-      ) {
-        return createResponse(
-          undefined,
-          'Invalid "params" field. Must be an array or object.',
-          400
-        );
-      }
+  //       const response = await executeTransaction(
+  //         queries,
+  //         isRaw,
+  //         this.dataSource,
+  //         this.config
+  //       );
+  //       return createResponse(response, undefined, 200);
+  //     } else if (typeof sql !== "string" || !sql.trim()) {
+  //       return createResponse(undefined, 'Invalid or empty "sql" field.', 400);
+  //     } else if (
+  //       params !== undefined &&
+  //       !Array.isArray(params) &&
+  //       typeof params !== "object"
+  //     ) {
+  //       return createResponse(
+  //         undefined,
+  //         'Invalid "params" field. Must be an array or object.',
+  //         400
+  //       );
+  //     }
 
-      const response = await executeQuery(
-        sql,
-        params,
-        isRaw,
-        this.dataSource,
-        this.config
-      );
-      return createResponse(response, undefined, 200);
-    } catch (error: any) {
-      console.error("Query Route Error:", error);
-      return createResponse(
-        undefined,
-        error?.message || "An unexpected error occurred.",
-        500
-      );
-    }
-  }
+  //     const response = await executeQuery(
+  //       sql,
+  //       params,
+  //       isRaw,
+  //       this.dataSource,
+  //       this.config
+  //     );
+  //     return createResponse(response, undefined, 200);
+  //   } catch (error: any) {
+  //     console.error("Query Route Error:", error);
+  //     return createResponse(
+  //       undefined,
+  //       error?.message || "An unexpected error occurred.",
+  //       500
+  //     );
+  //   }
+  // }
 
   clientConnected() {
     const webSocketPair = new WebSocketPair();

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -243,12 +243,13 @@ export class StarbaseDB {
           return { sql, params };
         });
 
-        const response = await executeTransaction(
+        const response = await executeTransaction({
           queries,
           isRaw,
-          this.dataSource,
-          this.config
-        );
+          dataSource: this.dataSource,
+          config: this.config,
+        });
+        
         return createResponse(response, undefined, 200);
       } else if (typeof sql !== "string" || !sql.trim()) {
         return createResponse(undefined, 'Invalid or empty "sql" field.', 400);

--- a/src/import/csv.ts
+++ b/src/import/csv.ts
@@ -1,6 +1,7 @@
 import { createResponse } from '../utils';
 import { DataSource } from '../types';
 import { executeOperation } from '../export';
+import { StarbaseDBConfiguration } from '../handler';
 
 interface ColumnMapping {
     [key: string]: string;
@@ -14,7 +15,8 @@ interface CsvData {
 export async function importTableFromCsvRoute(
     tableName: string,
     request: Request,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
         if (!request.body) {
@@ -67,7 +69,7 @@ export async function importTableFromCsvRoute(
             const statement = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
 
             try {
-                await executeOperation([{ sql: statement, params: values }], dataSource)
+                await executeOperation([{ sql: statement, params: values }], dataSource, config)
                 successCount++;
             } catch (error: any) {
                 failedStatements.push({

--- a/src/import/dump.ts
+++ b/src/import/dump.ts
@@ -1,6 +1,7 @@
 import { createResponse } from '../utils';
 import { DataSource } from '../types';
 import { executeOperation } from '../export';
+import { StarbaseDBConfiguration } from '../handler';
 
 function parseSqlStatements(sqlContent: string): string[] {
     const lines = sqlContent.split('\n');
@@ -31,7 +32,8 @@ function parseSqlStatements(sqlContent: string): string[] {
 
 export async function importDumpRoute(
     request: Request,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     if (request.method !== 'POST') {
         return createResponse(undefined, 'Method not allowed', 405);
@@ -66,7 +68,7 @@ export async function importDumpRoute(
         const results = [];
         for (const statement of sqlStatements) {
             try {
-                const result = await executeOperation([{ sql: statement }], dataSource)
+                const result = await executeOperation([{ sql: statement }], dataSource, config)
                 results.push({ statement, success: true, result });
             } catch (error: any) {
                 console.error(`Error executing statement: ${statement}`, error);

--- a/src/import/json.ts
+++ b/src/import/json.ts
@@ -1,6 +1,7 @@
 import { createResponse } from '../utils';
 import { executeOperation } from '../export';
 import { DataSource } from '../types';
+import { StarbaseDBConfiguration } from '../handler';
 
 interface ColumnMapping {
     [key: string]: string;
@@ -14,7 +15,8 @@ interface JsonData {
 export async function importTableFromJsonRoute(
     tableName: string,
     request: Request,
-    dataSource: DataSource
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
         if (!request.body) {
@@ -60,7 +62,7 @@ export async function importTableFromJsonRoute(
             const statement = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
 
             try {
-                await executeOperation([{ sql: statement, params: values }], dataSource)
+                await executeOperation([{ sql: statement, params: values }], dataSource, config)
                 successCount++;
             } catch (error: any) {
                 failedStatements.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ export default {
       };
 
       if (
-        env.EXTERNAL_DB_TYPE === "postgres" ||
+        env.EXTERNAL_DB_TYPE === "postgresql" ||
         env.EXTERNAL_DB_TYPE === "mysql"
       ) {
         dataSource.external = {

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -33,7 +33,7 @@ export class LiteREST {
     let query = `PRAGMA table_info(${tableName});`;
 
     if (this.dataSource.source === "external") {
-      if (this.dataSource.external?.dialect === "postgres") {
+      if (this.dataSource.external?.dialect === "postgresql") {
         query = `
                     SELECT kcu.column_name AS name 
                     FROM information_schema.table_constraints tc 

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -164,12 +164,12 @@ export class LiteREST {
   private async executeOperation(
     queries: { sql: string; params: any[] }[]
   ): Promise<{ result?: any; error?: string | undefined; status: number }> {
-    const results: any[] = (await executeTransaction(
-      queries,
-      false,
-      this.dataSource,
-      this.config
-    )) as any[];
+    const results: any[] = (await executeTransaction({
+        queries,
+        isRaw: false,
+        dataSource: this.dataSource,
+        config: this.config
+    })) as any[];
     return {
       result: results?.length > 0 ? results[0] : undefined,
       status: 200,

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -58,13 +58,13 @@ export class LiteREST {
       this.dataSource.source === "internal" ||
       this.dataSource.external?.dialect === "sqlite";
 
-    const schemaInfo = (await executeQuery(
-      query,
-      this.dataSource.source === "external" ? {} : [],
-      false,
-      this.dataSource,
-      this.config
-    )) as any[];
+    const schemaInfo = (await executeQuery({
+      sql: query,
+      params: [],
+      isRaw: false,
+      dataSource: this.dataSource,
+      config: this.config,
+    })) as any[];
 
     let pkColumns = [];
 
@@ -228,7 +228,7 @@ export class LiteREST {
     const pathParts = url.pathname.split("/").filter(Boolean);
 
     if (pathParts.length === 0) {
-      throw new Error("Invalid route");
+      throw new Error("Expected a table name in the path");
     }
 
     const tableName = this.sanitizeIdentifier(

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -1,40 +1,40 @@
-import { createResponse } from '../utils';
-import { DataSource, Source } from "../types";
+import { createResponse } from "../utils";
+import { DataSource } from "../types";
 import { executeQuery, executeTransaction } from "../operation";
-import { HandlerConfig } from "../handler"
+import { StarbaseDBConfiguration } from "../handler";
 
 export class LiteREST {
-    private dataSource: DataSource;
-    private config: HandlerConfig;
+  private dataSource: DataSource;
+  private config: StarbaseDBConfiguration;
 
-    constructor(
-        dataSource: DataSource,
-        config: HandlerConfig
-    ) {
-        this.dataSource = dataSource;
-        this.config = config;
-    }
+  constructor(dataSource: DataSource, config: StarbaseDBConfiguration) {
+    this.dataSource = dataSource;
+    this.config = config;
+  }
 
-    /**
-     * Sanitizes an identifier by removing all non-alphanumeric characters except underscores.
-     * @param identifier - The identifier to sanitize.
-     * @returns The sanitized identifier.
-     */
-    private sanitizeIdentifier(identifier: string): string {
-        return identifier.replace(/[^a-zA-Z0-9_]/g, '');
-    }
+  /**
+   * Sanitizes an identifier by removing all non-alphanumeric characters except underscores.
+   * @param identifier - The identifier to sanitize.
+   * @returns The sanitized identifier.
+   */
+  private sanitizeIdentifier(identifier: string): string {
+    return identifier.replace(/[^a-zA-Z0-9_]/g, "");
+  }
 
-    /**
-     * Retrieves the primary key columns for a given table.
-     * @param tableName - The name of the table.
-     * @returns An array of primary key column names.
-     */
-    private async getPrimaryKeyColumns(tableName: string, schemaName?: string): Promise<string[]> {
-        let query = `PRAGMA table_info(${tableName});`;
-    
-        if (this.dataSource.source === Source.external) {
-            if (this.config.externalDbType?.toLowerCase() === "postgres") {
-                query = `
+  /**
+   * Retrieves the primary key columns for a given table.
+   * @param tableName - The name of the table.
+   * @returns An array of primary key column names.
+   */
+  private async getPrimaryKeyColumns(
+    tableName: string,
+    schemaName?: string
+  ): Promise<string[]> {
+    let query = `PRAGMA table_info(${tableName});`;
+
+    if (this.dataSource.source === "external") {
+      if (this.dataSource.external?.dialect === "postgres") {
+        query = `
                     SELECT kcu.column_name AS name 
                     FROM information_schema.table_constraints tc 
                     JOIN information_schema.key_column_usage kcu 
@@ -43,395 +43,557 @@ export class LiteREST {
                     AND tc.table_name = kcu.table_name 
                     WHERE tc.constraint_type = 'PRIMARY KEY'
                     AND tc.table_name = '${tableName}' 
-                    AND tc.table_schema = '${schemaName ?? 'public'}';`;
-            } else if (this.config.externalDbType?.toLowerCase() === "mysql") {
-                query = `
+                    AND tc.table_schema = '${schemaName ?? "public"}';`;
+      } else if (this.dataSource.external?.dialect === "mysql") {
+        query = `
                     SELECT COLUMN_NAME AS name FROM information_schema.key_column_usage 
                     WHERE table_name = '${tableName}' 
                     AND constraint_name = 'PRIMARY'
-                    AND table_schema = ${schemaName ?? 'DATABASE()'};
+                    AND table_schema = ${schemaName ?? "DATABASE()"};
                 `;
-            }
-        }
-
-        const isSQLite = this.dataSource.source === Source.internal || this.config.externalDbType?.toLowerCase() === 'sqlite'
-        const schemaInfo = (await executeQuery(query, this.dataSource.source === Source.external ? {} : [], false, this.dataSource, this.config)) as any[];
-        
-        let pkColumns = []
-
-        if (isSQLite) {
-            pkColumns = schemaInfo
-                .filter(col => typeof col.pk === 'number' && col.pk > 0 && col.name !== null)
-                .map(col => col.name as string);
-        } else {
-            pkColumns = schemaInfo.map(col => col.name as string);
-        }
-
-        return pkColumns;
+      }
     }
 
-    /**
-     * Checks if the provided data is valid.
-     * @param data - The data to validate.
-     * @returns True if the data is valid, false otherwise.
-     */
-    private isDataValid(data: any): boolean {
-        return data && typeof data === 'object' && !Array.isArray(data);
+    const isSQLite =
+      this.dataSource.source === "internal" ||
+      this.dataSource.external?.dialect === "sqlite";
+
+    const schemaInfo = (await executeQuery(
+      query,
+      this.dataSource.source === "external" ? {} : [],
+      false,
+      this.dataSource,
+      this.config
+    )) as any[];
+
+    let pkColumns = [];
+
+    if (isSQLite) {
+      pkColumns = schemaInfo
+        .filter(
+          (col) => typeof col.pk === "number" && col.pk > 0 && col.name !== null
+        )
+        .map((col) => col.name as string);
+    } else {
+      pkColumns = schemaInfo.map((col) => col.name as string);
     }
 
-    /**
-     * Sanitizes an operator by mapping it to a valid SQL operator.
-     * @param operator - The operator to sanitize.
-     * @returns The sanitized operator.
-     */
-    private sanitizeOperator(operator: string | undefined): string {
-        const allowedOperators: { [key: string]: string } = {
-            'eq': '=',
-            'ne': '!=',
-            'gt': '>',
-            'lt': '<',
-            'gte': '>=',
-            'lte': '<=',
-            'like': 'LIKE',
-            'in': 'IN'
-        };
-        return allowedOperators[operator || 'eq'] || '=';
-    }
+    return pkColumns;
+  }
 
-    /**
-     * Retrieves the primary key conditions for a given table.
-     * @param pkColumns - The primary key columns for the table.
-     * @param id - The identifier for the record.
-     * @param data - The data to use for primary key conditions.
-     * @param searchParams - The search parameters.
-     * @returns An object containing the conditions, parameters, and any error message.
-     */
-    private getPrimaryKeyConditions(pkColumns: string[], id: string | undefined, data: any, searchParams: URLSearchParams): { conditions: string[], params: any[], error?: string } {
-        const conditions: string[] = [];
-        const params: any[] = [];
+  /**
+   * Checks if the provided data is valid.
+   * @param data - The data to validate.
+   * @returns True if the data is valid, false otherwise.
+   */
+  private isDataValid(data: any): boolean {
+    return data && typeof data === "object" && !Array.isArray(data);
+  }
 
-        if (pkColumns?.length === 1) {
-            const pk = pkColumns[0];
-            const pkValue = id || data[pk] || searchParams.get(pk);
-            if (!pkValue) {
-                return { conditions, params, error: `Missing primary key value for '${pk}'` };
-            }
-            conditions.push(`${pk} = ?`);
-            params.push(pkValue);
-        } else {
-            // Composite primary key
-            for (const pk of pkColumns) {
-                const pkValue = data[pk] || searchParams.get(pk);
-                if (!pkValue) {
-                    return { conditions, params, error: `Missing primary key value for '${pk}'` };
-                }
-                conditions.push(`${pk} = ?`);
-                params.push(pkValue);
-            }
-        }
+  /**
+   * Sanitizes an operator by mapping it to a valid SQL operator.
+   * @param operator - The operator to sanitize.
+   * @returns The sanitized operator.
+   */
+  private sanitizeOperator(operator: string | undefined): string {
+    const allowedOperators: { [key: string]: string } = {
+      eq: "=",
+      ne: "!=",
+      gt: ">",
+      lt: "<",
+      gte: ">=",
+      lte: "<=",
+      like: "LIKE",
+      in: "IN",
+    };
+    return allowedOperators[operator || "eq"] || "=";
+  }
 
-        return { conditions, params };
-    }
+  /**
+   * Retrieves the primary key conditions for a given table.
+   * @param pkColumns - The primary key columns for the table.
+   * @param id - The identifier for the record.
+   * @param data - The data to use for primary key conditions.
+   * @param searchParams - The search parameters.
+   * @returns An object containing the conditions, parameters, and any error message.
+   */
+  private getPrimaryKeyConditions(
+    pkColumns: string[],
+    id: string | undefined,
+    data: any,
+    searchParams: URLSearchParams
+  ): { conditions: string[]; params: any[]; error?: string } {
+    const conditions: string[] = [];
+    const params: any[] = [];
 
-    /**
-     * Executes a set of operations.
-     * @param queries - The operations to execute.
-     */
-    private async executeOperation(queries: { sql: string, params: any[] }[]): Promise<{ result?: any, error?: string | undefined, status: number }> {
-        const results: any[] = (await executeTransaction(queries, false, this.dataSource, this.config)) as any[];
-        return { result: results?.length > 0 ? results[0] : undefined, status: 200 };
-    }
-
-    /**
-     * Handles the incoming request and determines the appropriate action based on the method and path.
-     * @param request - The incoming request.
-     * @returns The response to the request.
-     */
-    async handleRequest(request: Request): Promise<Response> {
-        const { method, tableName, schemaName, id, searchParams, body } = await this.parseRequest(request);
-
-        try {
-            switch (method) {
-                case 'GET':
-                    return await this.handleGet(tableName, schemaName, id, searchParams);
-                case 'POST':
-                    return await this.handlePost(tableName, schemaName, body);
-                case 'PATCH':
-                    return await this.handlePatch(tableName, schemaName, id, body);
-                case 'PUT':
-                    return await this.handlePut(tableName, schemaName, id, body);
-                case 'DELETE':
-                    return await this.handleDelete(tableName, schemaName, id);
-                default:
-                    return createResponse(undefined, 'Method not allowed', 405);
-            }
-        } catch (error: any) {
-            console.error('LiteREST Error:', error);
-            return createResponse(undefined, error.message || 'An unexpected error occurred', 500);
-        }
-    }
-
-    /**
-     * Parses the incoming request and extracts the method, table name, id, search parameters, and body.
-     * @param request - The incoming request.
-     * @returns An object containing the method, table name, id, search parameters, and body.
-     */
-    private async parseRequest(request: Request): Promise<{ method: string, tableName: string, schemaName: string | undefined, id?: string, searchParams: URLSearchParams, body?: any }> {
-        const liteRequest = new Request(request.url.replace('/rest', ''), request);
-        const url = new URL(liteRequest.url);
-        const pathParts = url.pathname.split('/').filter(Boolean);
-
-        if (pathParts.length === 0) {
-            throw new Error('Invalid route');
-        }
-
-        const tableName = this.sanitizeIdentifier(pathParts.length === 1 ? pathParts[0] : pathParts[1]);
-        const schemaName = this.sanitizeIdentifier(pathParts[0]);
-        const id = pathParts.length === 3 ? pathParts[2] : undefined;
-        const body = ['POST', 'PUT', 'PATCH'].includes(liteRequest.method) ? await liteRequest.json() : undefined;
-
+    if (pkColumns?.length === 1) {
+      const pk = pkColumns[0];
+      const pkValue = id || data[pk] || searchParams.get(pk);
+      if (!pkValue) {
         return {
-            method: liteRequest.method,
-            tableName,
-            schemaName,
-            id,
-            searchParams: url.searchParams,
-            body
+          conditions,
+          params,
+          error: `Missing primary key value for '${pk}'`,
         };
+      }
+      conditions.push(`${pk} = ?`);
+      params.push(pkValue);
+    } else {
+      // Composite primary key
+      for (const pk of pkColumns) {
+        const pkValue = data[pk] || searchParams.get(pk);
+        if (!pkValue) {
+          return {
+            conditions,
+            params,
+            error: `Missing primary key value for '${pk}'`,
+          };
+        }
+        conditions.push(`${pk} = ?`);
+        params.push(pkValue);
+      }
     }
 
-    private async buildSelectQuery(tableName: string, schemaName: string | undefined, id: string | undefined, searchParams: URLSearchParams): Promise<{ query: string, params: any[] }> {
-        let query = `SELECT * FROM ${schemaName ? `${schemaName}.` : ''}${tableName}`;
-        const params: any[] = [];
-        const conditions: string[] = [];
-        const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
-        const { conditions: pkConditions, params: pkParams, error } = this.getPrimaryKeyConditions(pkColumns, id, {}, searchParams);
-    
-        if (!error) {
-            conditions.push(...pkConditions);
-            params.push(...pkParams);
-        }
-    
-        // Extract special parameters
-        const sortBy = searchParams.get('sort_by');
-        const orderParam = searchParams.get('order');
-        const limitParam = searchParams.get('limit');
-        const offsetParam = searchParams.get('offset');
-    
-        // Remove special parameters from searchParams
-        ['sort_by', 'order', 'limit', 'offset'].forEach(param => searchParams.delete(param));
-    
-        // Handle other search parameters
-        for (const [key, value] of searchParams.entries()) {
-            if (pkColumns.includes(key)) continue; // Skip primary key columns
-            const [column, op] = key.split('.');
-            const sanitizedColumn = this.sanitizeIdentifier(column);
-            const operator = this.sanitizeOperator(op);
-    
-            if (operator === 'IN') {
-                const values = value.split(',').map(val => val.trim());
-                const placeholders = values.map(() => '?').join(', ');
-                conditions.push(`${sanitizedColumn} IN (${placeholders})`);
-                params.push(...values);
-            } else {
-                conditions.push(`${sanitizedColumn} ${operator} ?`);
-                params.push(value);
-            }
-        }
-    
-        // Add WHERE clause if there are conditions
-        if (conditions.length > 0) {
-            query += ` WHERE ${conditions.join(' AND ')}`;
-        }
-    
-        // Add ORDER BY clause
-        if (sortBy) {
-            const sanitizedSortBy = this.sanitizeIdentifier(sortBy);
-            const order = orderParam?.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
-            query += ` ORDER BY ${sanitizedSortBy} ${order}`;
-        }
-    
-        // Add LIMIT and OFFSET clauses
-        if (limitParam) {
-            const limit = parseInt(limitParam, 10);
-            if (limit > 0) {
-                query += ` LIMIT ?`;
-                params.push(limit);
-    
-                if (offsetParam) {
-                    const offset = parseInt(offsetParam, 10);
-                    if (offset > 0) {
-                        query += ` OFFSET ?`;
-                        params.push(offset);
-                    }
-                }
-            }
-        }
-    
-        return { query, params };
+    return { conditions, params };
+  }
+
+  /**
+   * Executes a set of operations.
+   * @param queries - The operations to execute.
+   */
+  private async executeOperation(
+    queries: { sql: string; params: any[] }[]
+  ): Promise<{ result?: any; error?: string | undefined; status: number }> {
+    const results: any[] = (await executeTransaction(
+      queries,
+      false,
+      this.dataSource,
+      this.config
+    )) as any[];
+    return {
+      result: results?.length > 0 ? results[0] : undefined,
+      status: 200,
+    };
+  }
+
+  /**
+   * Handles the incoming request and determines the appropriate action based on the method and path.
+   * @param request - The incoming request.
+   * @returns The response to the request.
+   */
+  async handleRequest(request: Request): Promise<Response> {
+    const { method, tableName, schemaName, id, searchParams, body } =
+      await this.parseRequest(request);
+
+    try {
+      switch (method) {
+        case "GET":
+          return await this.handleGet(tableName, schemaName, id, searchParams);
+        case "POST":
+          return await this.handlePost(tableName, schemaName, body);
+        case "PATCH":
+          return await this.handlePatch(tableName, schemaName, id, body);
+        case "PUT":
+          return await this.handlePut(tableName, schemaName, id, body);
+        case "DELETE":
+          return await this.handleDelete(tableName, schemaName, id);
+        default:
+          return createResponse(undefined, "Method not allowed", 405);
+      }
+    } catch (error: any) {
+      console.error("LiteREST Error:", error);
+      return createResponse(
+        undefined,
+        error.message || "An unexpected error occurred",
+        500
+      );
+    }
+  }
+
+  /**
+   * Parses the incoming request and extracts the method, table name, id, search parameters, and body.
+   * @param request - The incoming request.
+   * @returns An object containing the method, table name, id, search parameters, and body.
+   */
+  private async parseRequest(request: Request): Promise<{
+    method: string;
+    tableName: string;
+    schemaName: string | undefined;
+    id?: string;
+    searchParams: URLSearchParams;
+    body?: any;
+  }> {
+    const liteRequest = new Request(request.url.replace("/rest", ""), request);
+    const url = new URL(liteRequest.url);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+
+    if (pathParts.length === 0) {
+      throw new Error("Invalid route");
     }
 
-    private async handleGet(tableName: string, schemaName: string | undefined, id: string | undefined, searchParams: URLSearchParams): Promise<Response> {
-        const { query, params } = await this.buildSelectQuery(tableName, schemaName, id, searchParams);
+    const tableName = this.sanitizeIdentifier(
+      pathParts.length === 1 ? pathParts[0] : pathParts[1]
+    );
+    const schemaName = this.sanitizeIdentifier(pathParts[0]);
+    const id = pathParts.length === 3 ? pathParts[2] : undefined;
+    const body = ["POST", "PUT", "PATCH"].includes(liteRequest.method)
+      ? await liteRequest.json()
+      : undefined;
 
-        try {
-            const response = await this.executeOperation([{ sql: query, params }]);
-            const resultArray = response.result;
-            return createResponse(resultArray, undefined, 200);
-        } catch (error: any) {
-            console.error('GET Operation Error:', error);
-            return createResponse(undefined, error.message || 'Failed to retrieve data', 500);
-        }
-    } 
+    return {
+      method: liteRequest.method,
+      tableName,
+      schemaName,
+      id,
+      searchParams: url.searchParams,
+      body,
+    };
+  }
 
-    private async handlePost(tableName: string, schemaName: string | undefined, data: any): Promise<Response> {
-        if (!this.isDataValid(data)) {
-            console.error('Invalid data format for POST:', data);
-            return createResponse(undefined, 'Invalid data format', 400);
-        }
+  private async buildSelectQuery(
+    tableName: string,
+    schemaName: string | undefined,
+    id: string | undefined,
+    searchParams: URLSearchParams
+  ): Promise<{ query: string; params: any[] }> {
+    let query = `SELECT * FROM ${
+      schemaName ? `${schemaName}.` : ""
+    }${tableName}`;
+    const params: any[] = [];
+    const conditions: string[] = [];
+    const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
+    const {
+      conditions: pkConditions,
+      params: pkParams,
+      error,
+    } = this.getPrimaryKeyConditions(pkColumns, id, {}, searchParams);
 
-        const dataKeys = Object.keys(data);
-        if (dataKeys.length === 0) {
-            console.error('No data provided for POST');
-            return createResponse(undefined, 'No data provided', 400);
-        }
-
-        // Sanitize column names
-        const columns = dataKeys.map(col => this.sanitizeIdentifier(col));
-        const placeholders = columns.map(() => '?').join(', ');
-        const query = `INSERT INTO ${schemaName ? `${schemaName}.` : ''}${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
-
-        // Map parameters using original data keys to get correct values
-        const params = dataKeys.map(key => data[key]);
-        const queries = [{ sql: query, params }];
-
-        try {
-            await this.executeOperation(queries);
-            return createResponse({ message: 'Resource created successfully', data }, undefined, 201);
-        } catch (error: any) {
-            console.error('POST Operation Error:', error);
-            const errorMessage = error.message || error.error || JSON.stringify(error) || 'Failed to create resource';
-            return createResponse(undefined, errorMessage, 500);
-        }
+    if (!error) {
+      conditions.push(...pkConditions);
+      params.push(...pkParams);
     }
 
-    private async handlePatch(tableName: string, schemaName: string | undefined, id: string | undefined, data: any): Promise<Response> {
-        const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
+    // Extract special parameters
+    const sortBy = searchParams.get("sort_by");
+    const orderParam = searchParams.get("order");
+    const limitParam = searchParams.get("limit");
+    const offsetParam = searchParams.get("offset");
 
-        const { conditions: pkConditions, params: pkParams, error } = this.getPrimaryKeyConditions(pkColumns, id, data, new URLSearchParams());
+    // Remove special parameters from searchParams
+    ["sort_by", "order", "limit", "offset"].forEach((param) =>
+      searchParams.delete(param)
+    );
 
-        if (error) {
-            console.error('PATCH Operation Error:', error);
-            return createResponse(undefined, error, 400);
-        }
+    // Handle other search parameters
+    for (const [key, value] of searchParams.entries()) {
+      if (pkColumns.includes(key)) continue; // Skip primary key columns
+      const [column, op] = key.split(".");
+      const sanitizedColumn = this.sanitizeIdentifier(column);
+      const operator = this.sanitizeOperator(op);
 
-        if (!this.isDataValid(data)) {
-            console.error('Invalid data format for PATCH:', data);
-            return createResponse(undefined, 'Invalid data format', 400);
-        }
-
-        const dataKeys = Object.keys(data);
-        if (dataKeys.length === 0) {
-            console.error('No data provided for PATCH');
-            return createResponse(undefined, 'No data provided', 400);
-        }
-
-        // Remove primary key columns from dataKeys
-        const updateKeys = dataKeys.filter(key => !pkColumns.includes(key));
-
-        if (updateKeys.length === 0) {
-            console.error('No updatable data provided for PATCH');
-            return createResponse(undefined, 'No updatable data provided', 400);
-        }
-
-        // Sanitize column names
-        const columns = updateKeys.map(col => this.sanitizeIdentifier(col));
-        const setClause = columns.map(col => `${col} = ?`).join(', ');
-        const query = `UPDATE ${schemaName ? `${schemaName}.` : ''}${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
-
-        // Map parameters using original data keys to get correct values
-        const params = updateKeys.map(key => data[key]);
-        params.push(...pkParams);
-
-        const queries = [{ sql: query, params }];
-
-        try {
-            await this.executeOperation(queries);
-            return createResponse({ message: 'Resource updated successfully', data }, undefined, 200);
-        } catch (error: any) {
-            console.error('PATCH Operation Error:', error);
-            return createResponse(undefined, error.message || 'Failed to update resource', 500);
-        }
-    }
-    
-    private async handlePut(tableName: string, schemaName: string | undefined, id: string | undefined, data: any): Promise<Response> {
-        const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
-
-        const { conditions: pkConditions, params: pkParams, error } = this.getPrimaryKeyConditions(pkColumns, id, data, new URLSearchParams());
-
-        if (error) {
-            console.error('PUT Operation Error:', error);
-            return createResponse(undefined, error, 400);
-        }
-
-        if (!this.isDataValid(data)) {
-            console.error('Invalid data format for PUT:', data);
-            return createResponse(undefined, 'Invalid data format', 400);
-        }
-
-        const dataKeys = Object.keys(data);
-        if (dataKeys.length === 0) {
-            console.error('No data provided for PUT');
-            return createResponse(undefined, 'No data provided', 400);
-        }
-
-        // Sanitize column names
-        const columns = dataKeys.map(col => this.sanitizeIdentifier(col));
-        const setClause = columns.map(col => `${col} = ?`).join(', ');
-        const query = `UPDATE ${schemaName ? `${schemaName}.` : ''}${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
-
-        // Map parameters using original data keys to get correct values
-        const params = dataKeys.map(key => data[key]);
-        params.push(...pkParams);
-
-        const queries = [{ sql: query, params }];
-
-        try {
-            await this.executeOperation(queries);
-            return createResponse({ message: 'Resource replaced successfully', data }, undefined, 200);
-        } catch (error: any) {
-            console.error('PUT Operation Error:', error);
-            return createResponse(undefined, error.message || 'Failed to replace resource', 500);
-        }
+      if (operator === "IN") {
+        const values = value.split(",").map((val) => val.trim());
+        const placeholders = values.map(() => "?").join(", ");
+        conditions.push(`${sanitizedColumn} IN (${placeholders})`);
+        params.push(...values);
+      } else {
+        conditions.push(`${sanitizedColumn} ${operator} ?`);
+        params.push(value);
+      }
     }
 
-    private async handleDelete(tableName: string, schemaName: string | undefined, id: string | undefined): Promise<Response> {
-        const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
-
-        let data: any = {}
-
-        // Currently the DELETE only works with single primary key tables.
-        if (pkColumns.length) {
-            const firstPK = pkColumns[0]
-            data[firstPK] = id
-        }
-
-        const { conditions: pkConditions, params: pkParams, error } = this.getPrimaryKeyConditions(pkColumns, id, data, new URLSearchParams());
-
-        if (error) {
-            console.error('DELETE Operation Error:', error);
-            return createResponse(undefined, error, 400);
-        }
-
-        const query = `DELETE FROM ${schemaName ? `${schemaName}.` : ''}${tableName} WHERE ${pkConditions.join(' AND ')}`;
-        const queries = [{ sql: query, params: pkParams }];
-
-        try {
-            await this.executeOperation(queries);
-            return createResponse({ message: 'Resource deleted successfully' }, undefined, 200);
-        } catch (error: any) {
-            console.error('DELETE Operation Error:', error);
-            return createResponse(undefined, error.message || 'Failed to delete resource', 500);
-        }
+    // Add WHERE clause if there are conditions
+    if (conditions.length > 0) {
+      query += ` WHERE ${conditions.join(" AND ")}`;
     }
+
+    // Add ORDER BY clause
+    if (sortBy) {
+      const sanitizedSortBy = this.sanitizeIdentifier(sortBy);
+      const order = orderParam?.toUpperCase() === "DESC" ? "DESC" : "ASC";
+      query += ` ORDER BY ${sanitizedSortBy} ${order}`;
+    }
+
+    // Add LIMIT and OFFSET clauses
+    if (limitParam) {
+      const limit = parseInt(limitParam, 10);
+      if (limit > 0) {
+        query += ` LIMIT ?`;
+        params.push(limit);
+
+        if (offsetParam) {
+          const offset = parseInt(offsetParam, 10);
+          if (offset > 0) {
+            query += ` OFFSET ?`;
+            params.push(offset);
+          }
+        }
+      }
+    }
+
+    return { query, params };
+  }
+
+  private async handleGet(
+    tableName: string,
+    schemaName: string | undefined,
+    id: string | undefined,
+    searchParams: URLSearchParams
+  ): Promise<Response> {
+    const { query, params } = await this.buildSelectQuery(
+      tableName,
+      schemaName,
+      id,
+      searchParams
+    );
+
+    try {
+      const response = await this.executeOperation([{ sql: query, params }]);
+      const resultArray = response.result;
+      return createResponse(resultArray, undefined, 200);
+    } catch (error: any) {
+      console.error("GET Operation Error:", error);
+      return createResponse(
+        undefined,
+        error.message || "Failed to retrieve data",
+        500
+      );
+    }
+  }
+
+  private async handlePost(
+    tableName: string,
+    schemaName: string | undefined,
+    data: any
+  ): Promise<Response> {
+    if (!this.isDataValid(data)) {
+      console.error("Invalid data format for POST:", data);
+      return createResponse(undefined, "Invalid data format", 400);
+    }
+
+    const dataKeys = Object.keys(data);
+    if (dataKeys.length === 0) {
+      console.error("No data provided for POST");
+      return createResponse(undefined, "No data provided", 400);
+    }
+
+    // Sanitize column names
+    const columns = dataKeys.map((col) => this.sanitizeIdentifier(col));
+    const placeholders = columns.map(() => "?").join(", ");
+    const query = `INSERT INTO ${
+      schemaName ? `${schemaName}.` : ""
+    }${tableName} (${columns.join(", ")}) VALUES (${placeholders})`;
+
+    // Map parameters using original data keys to get correct values
+    const params = dataKeys.map((key) => data[key]);
+    const queries = [{ sql: query, params }];
+
+    try {
+      await this.executeOperation(queries);
+      return createResponse(
+        { message: "Resource created successfully", data },
+        undefined,
+        201
+      );
+    } catch (error: any) {
+      console.error("POST Operation Error:", error);
+      const errorMessage =
+        error.message ||
+        error.error ||
+        JSON.stringify(error) ||
+        "Failed to create resource";
+      return createResponse(undefined, errorMessage, 500);
+    }
+  }
+
+  private async handlePatch(
+    tableName: string,
+    schemaName: string | undefined,
+    id: string | undefined,
+    data: any
+  ): Promise<Response> {
+    const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
+
+    const {
+      conditions: pkConditions,
+      params: pkParams,
+      error,
+    } = this.getPrimaryKeyConditions(
+      pkColumns,
+      id,
+      data,
+      new URLSearchParams()
+    );
+
+    if (error) {
+      console.error("PATCH Operation Error:", error);
+      return createResponse(undefined, error, 400);
+    }
+
+    if (!this.isDataValid(data)) {
+      console.error("Invalid data format for PATCH:", data);
+      return createResponse(undefined, "Invalid data format", 400);
+    }
+
+    const dataKeys = Object.keys(data);
+    if (dataKeys.length === 0) {
+      console.error("No data provided for PATCH");
+      return createResponse(undefined, "No data provided", 400);
+    }
+
+    // Remove primary key columns from dataKeys
+    const updateKeys = dataKeys.filter((key) => !pkColumns.includes(key));
+
+    if (updateKeys.length === 0) {
+      console.error("No updatable data provided for PATCH");
+      return createResponse(undefined, "No updatable data provided", 400);
+    }
+
+    // Sanitize column names
+    const columns = updateKeys.map((col) => this.sanitizeIdentifier(col));
+    const setClause = columns.map((col) => `${col} = ?`).join(", ");
+    const query = `UPDATE ${
+      schemaName ? `${schemaName}.` : ""
+    }${tableName} SET ${setClause} WHERE ${pkConditions.join(" AND ")}`;
+
+    // Map parameters using original data keys to get correct values
+    const params = updateKeys.map((key) => data[key]);
+    params.push(...pkParams);
+
+    const queries = [{ sql: query, params }];
+
+    try {
+      await this.executeOperation(queries);
+      return createResponse(
+        { message: "Resource updated successfully", data },
+        undefined,
+        200
+      );
+    } catch (error: any) {
+      console.error("PATCH Operation Error:", error);
+      return createResponse(
+        undefined,
+        error.message || "Failed to update resource",
+        500
+      );
+    }
+  }
+
+  private async handlePut(
+    tableName: string,
+    schemaName: string | undefined,
+    id: string | undefined,
+    data: any
+  ): Promise<Response> {
+    const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
+
+    const {
+      conditions: pkConditions,
+      params: pkParams,
+      error,
+    } = this.getPrimaryKeyConditions(
+      pkColumns,
+      id,
+      data,
+      new URLSearchParams()
+    );
+
+    if (error) {
+      console.error("PUT Operation Error:", error);
+      return createResponse(undefined, error, 400);
+    }
+
+    if (!this.isDataValid(data)) {
+      console.error("Invalid data format for PUT:", data);
+      return createResponse(undefined, "Invalid data format", 400);
+    }
+
+    const dataKeys = Object.keys(data);
+    if (dataKeys.length === 0) {
+      console.error("No data provided for PUT");
+      return createResponse(undefined, "No data provided", 400);
+    }
+
+    // Sanitize column names
+    const columns = dataKeys.map((col) => this.sanitizeIdentifier(col));
+    const setClause = columns.map((col) => `${col} = ?`).join(", ");
+    const query = `UPDATE ${
+      schemaName ? `${schemaName}.` : ""
+    }${tableName} SET ${setClause} WHERE ${pkConditions.join(" AND ")}`;
+
+    // Map parameters using original data keys to get correct values
+    const params = dataKeys.map((key) => data[key]);
+    params.push(...pkParams);
+
+    const queries = [{ sql: query, params }];
+
+    try {
+      await this.executeOperation(queries);
+      return createResponse(
+        { message: "Resource replaced successfully", data },
+        undefined,
+        200
+      );
+    } catch (error: any) {
+      console.error("PUT Operation Error:", error);
+      return createResponse(
+        undefined,
+        error.message || "Failed to replace resource",
+        500
+      );
+    }
+  }
+
+  private async handleDelete(
+    tableName: string,
+    schemaName: string | undefined,
+    id: string | undefined
+  ): Promise<Response> {
+    const pkColumns = await this.getPrimaryKeyColumns(tableName, schemaName);
+
+    let data: any = {};
+
+    // Currently the DELETE only works with single primary key tables.
+    if (pkColumns.length) {
+      const firstPK = pkColumns[0];
+      data[firstPK] = id;
+    }
+
+    const {
+      conditions: pkConditions,
+      params: pkParams,
+      error,
+    } = this.getPrimaryKeyConditions(
+      pkColumns,
+      id,
+      data,
+      new URLSearchParams()
+    );
+
+    if (error) {
+      console.error("DELETE Operation Error:", error);
+      return createResponse(undefined, error, 400);
+    }
+
+    const query = `DELETE FROM ${
+      schemaName ? `${schemaName}.` : ""
+    }${tableName} WHERE ${pkConditions.join(" AND ")}`;
+    const queries = [{ sql: query, params: pkParams }];
+
+    try {
+      await this.executeOperation(queries);
+      return createResponse(
+        { message: "Resource deleted successfully" },
+        undefined,
+        200
+      );
+    } catch (error: any) {
+      console.error("DELETE Operation Error:", error);
+      return createResponse(
+        undefined,
+        error.message || "Failed to delete resource",
+        500
+      );
+    }
+  }
 }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -6,7 +6,6 @@ import { createClient as createTursoConnection } from "@libsql/client/web";
 // Import how we interact with the databases through the Outerbase SDK
 import {
   CloudflareD1Connection,
-  // MongoDBConnection,
   MySQLConnection,
   PostgreSQLConnection,
   StarbaseConnection,
@@ -20,7 +19,6 @@ import {
   TursoDBSource,
 } from "./types";
 import { StarbaseDBConfiguration } from "./handler";
-// import { MongoClient } from "mongodb";
 import { afterQueryCache, beforeQueryCache } from "./cache";
 import { isQueryAllowed } from "./allowlist";
 import { applyRLS } from "./rls";
@@ -320,21 +318,6 @@ async function createSDKMySQLConnection(
     defaultSchema: source.defaultSchema || "public",
   };
 }
-
-// TODO: Disabled Mongo connection for now since it doesn't support RLS / Allow List
-// async function createSDKMongoConnection(
-//   config: StarbaseDBConfiguration
-// ): Promise<ConnectionDetails> {
-//   const client = new MongoDBConnection(
-//     new MongoClient(config.externalDbMongodbUri as string),
-//     config.externalDbName as string
-//   );
-
-//   return {
-//     database: client,
-//     defaultSchema: config.externalDbName || "",
-//   };
-// }
 
 async function createSDKTursoConnection(
   source: TursoDBSource

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -396,7 +396,7 @@ export async function executeSDKQuery(opts: {
 
   let connection: SqlConnection;
 
-  if (external.dialect === "postgres") {
+  if (external.dialect === "postgresql") {
     const { database } = await createSDKPostgresConnection(external);
     connection = database;
   } else if (external.dialect === "mysql") {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,311 +1,411 @@
 // Import the native Node libraries for connecting to various databases
-import { Client as PgClient } from 'pg';
-import { createConnection as createMySqlConnection } from 'mysql2';
-import { createClient as createTursoConnection } from '@libsql/client/web';
+import { Client as PgClient } from "pg";
+import { createConnection as createMySqlConnection } from "mysql2";
+import { createClient as createTursoConnection } from "@libsql/client/web";
 
 // Import how we interact with the databases through the Outerbase SDK
-import { CloudflareD1Connection, MongoDBConnection, MySQLConnection, PostgreSQLConnection, StarbaseConnection, TursoConnection } from '@outerbase/sdk';
-import { DataSource, Source } from './types';
-import { Handler, HandlerConfig } from './handler'
-import { MongoClient } from 'mongodb';
-import { afterQueryCache, beforeQueryCache } from './cache';
-import { isQueryAllowed } from './allowlist';
-import { applyRLS } from './rls';
-
-let globalConnection: any = null;
+import {
+  CloudflareD1Connection,
+  MongoDBConnection,
+  MySQLConnection,
+  PostgreSQLConnection,
+  StarbaseConnection,
+  TursoConnection,
+} from "@outerbase/sdk";
+import {
+  CloudflareD1Source,
+  DataSource,
+  RemoteSource,
+  StarbaseDBSource,
+  TursoDBSource,
+} from "./types";
+import { StarbaseDBConfiguration } from "./handler";
+// import { MongoClient } from "mongodb";
+import { afterQueryCache, beforeQueryCache } from "./cache";
+import { isQueryAllowed } from "./allowlist";
+import { applyRLS } from "./rls";
+import type { SqlConnection } from "@outerbase/sdk/dist/connections/sql-base";
 
 export type OperationQueueItem = {
-    queries: { sql: string; params?: any[] }[];
-    isTransaction: boolean;
-    isRaw: boolean;
-    resolve: (value: any) => void;
-    reject: (reason?: any) => void;
-}
+  queries: { sql: string; params?: any[] }[];
+  isTransaction: boolean;
+  isRaw: boolean;
+  resolve: (value: any) => void;
+  reject: (reason?: any) => void;
+};
 
 export type RawQueryResponse = {
-    columns: string[];
-    rows: any[];
-    meta: {
-        rows_read: number;
-        rows_written: number;
-    }
-}
+  columns: string[];
+  rows: unknown[];
+  meta: {
+    rows_read: number;
+    rows_written: number;
+  };
+};
 
-export type QueryResponse = any[] | RawQueryResponse;
+export type QueryResponse = unknown[] | RawQueryResponse;
 
 export type ConnectionDetails = {
-    database: any,
-    defaultSchema: string,
+  database: SqlConnection;
+  defaultSchema: string;
+};
+
+async function beforeQuery(
+  sql: string,
+  params?: any[],
+  dataSource?: DataSource,
+  config?: StarbaseDBConfiguration
+): Promise<{ sql: string; params?: any[] }> {
+  // ## DO NOT REMOVE: PRE QUERY HOOK ##
+
+  return {
+    sql,
+    params,
+  };
 }
 
-async function beforeQuery(sql: string, params?: any[], dataSource?: DataSource, config?: HandlerConfig): Promise<{ sql: string, params?: any[] }> {
-    // ## DO NOT REMOVE: PRE QUERY HOOK ##
-    
+async function afterQuery(
+  sql: string,
+  result: any,
+  isRaw: boolean,
+  dataSource?: DataSource,
+  config?: StarbaseDBConfiguration
+): Promise<any> {
+  result = isRaw ? transformRawResults(result, "from") : result;
+
+  // ## DO NOT REMOVE: POST QUERY HOOK ##
+
+  return isRaw ? transformRawResults(result, "to") : result;
+}
+
+function transformRawResults(
+  result: any,
+  direction: "to" | "from"
+): Record<string, any> {
+  if (direction === "from") {
+    // Convert our result from the `raw` output to a traditional object
+    result = {
+      ...result,
+      rows: result.rows.map((row: any) =>
+        result.columns.reduce((obj: any, column: string, index: number) => {
+          obj[column] = row[index];
+          return obj;
+        }, {})
+      ),
+    };
+
+    return result.rows;
+  } else if (direction === "to") {
+    // Convert our traditional object to the `raw` output format
+    const columns = Object.keys(result[0] || {});
+    const rows = result.map((row: any) => columns.map((col) => row[col]));
+
     return {
-        sql,
-        params
-    }
-}
+      columns,
+      rows,
+      meta: {
+        rows_read: rows.length,
+        rows_written: 0,
+      },
+    };
+  }
 
-async function afterQuery(sql: string, result: any, isRaw: boolean, dataSource?: DataSource, config?: HandlerConfig): Promise<any> {
-    result = isRaw ? transformRawResults(result, 'from') : result;
-
-    // ## DO NOT REMOVE: POST QUERY HOOK ##
-
-    return isRaw ? transformRawResults(result, 'to') : result;
-}
-
-function transformRawResults(result: any, direction: 'to' | 'from'): Record<string, any> {
-    if (direction === 'from') {
-        // Convert our result from the `raw` output to a traditional object
-        result = {
-            ...result,
-            rows: result.rows.map((row: any) => 
-                result.columns.reduce((obj: any, column: string, index: number) => {
-                    obj[column] = row[index];
-                    return obj;
-                }, {})
-            )
-        };
-
-        return result.rows
-    } else if (direction === 'to') {
-        // Convert our traditional object to the `raw` output format
-        const columns = Object.keys(result[0] || {});
-        const rows = result.map((row: any) => columns.map(col => row[col]));
-        
-        return {
-            columns,
-            rows,
-            meta: {
-                rows_read: rows.length,
-                rows_written: 0
-            }
-        };
-    }
-    
-    return result
+  return result;
 }
 
 // Outerbase API supports more data sources than can be supported via Cloudflare Workers. For those data
 // sources we recommend you connect your database to Outerbase and provide the bases API key for queries
 // to be made. Otherwise, for supported data sources such as Postgres, MySQL, D1, StarbaseDB, Turso and Mongo
 // we can connect to the database directly and remove the additional hop to the Outerbase API.
-async function executeExternalQuery(sql: string, params: any, isRaw: boolean, dataSource: DataSource, config?: HandlerConfig): Promise<any> {
-    if (!dataSource.externalConnection) {
-        throw new Error('External connection not found.');
-    }
+async function executeExternalQuery(
+  sql: string,
+  params: any,
+  dataSource: DataSource,
+  config: StarbaseDBConfiguration
+): Promise<any> {
+  if (!dataSource.external) {
+    throw new Error("External connection not found.");
+  }
 
-    // If not an Outerbase API request, forward to external database.
-    if (!config?.outerbaseApiKey) {
-        return await executeSDKQuery(sql, params, isRaw, dataSource, config);
-    }
+  // If not an Outerbase API request, forward to external database.
+  if (!config?.outerbaseApiKey) {
+    return await executeSDKQuery({ sql, params, dataSource, config });
+  }
 
-    // Convert params from array to object if needed
-    let convertedParams = params;
-    if (Array.isArray(params)) {
-        let paramIndex = 0;
-        convertedParams = params.reduce((acc, value, index) => ({
-            ...acc,
-            [`param${index}`]: value
-        }), {});
-        sql = sql.replace(/\?/g, () => `:param${paramIndex++}`);
-    }
+  // Convert params from array to object if needed
+  let convertedParams = params;
+  if (Array.isArray(params)) {
+    let paramIndex = 0;
+    convertedParams = params.reduce(
+      (acc, value, index) => ({
+        ...acc,
+        [`param${index}`]: value,
+      }),
+      {}
+    );
+    sql = sql.replace(/\?/g, () => `:param${paramIndex++}`);
+  }
 
+  const API_URL = "https://app.outerbase.com";
+  const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Source-Token": config.outerbaseApiKey,
+    },
+    body: JSON.stringify({
+      query: sql.replaceAll("\n", " "),
+      params: convertedParams,
+    }),
+  });
 
-    const API_URL = 'https://app.outerbase.com';
-    const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
-        },
-        body: JSON.stringify({
-            query: sql.replaceAll('\n', ' '),
-            params: convertedParams,
-        }),
-    });
-
-    const results: any = await response.json();
-    return results.response.results?.items;
+  const results: any = await response.json();
+  return results.response.results?.items;
 }
 
-export async function executeQuery(sql: string, params: any | undefined, isRaw: boolean, dataSource?: DataSource, config?: HandlerConfig): Promise<QueryResponse> {
-    if (!dataSource) {
-        console.error('Data source not found.')
-        return []
-    }
+export async function executeQuery(
+  sql: string,
+  params: any | undefined,
+  isRaw: boolean,
+  dataSource?: DataSource,
+  config?: StarbaseDBConfiguration
+): Promise<QueryResponse> {
+  if (!dataSource) {
+    console.error("Data source not found.");
+    return [];
+  }
 
-    try {
-        // If the allowlist feature is enabled, we should verify the query is allowed before proceeding.
-        await isQueryAllowed(sql, config?.enableAllowlist ?? false, dataSource, config)
-
-        // If the row level security feature is enabled, we should apply our policies to this SQL statement.
-        sql = await applyRLS(sql, config?.enableRls ?? false, config?.externalDbType, dataSource, config)
-        
-        // Run the beforeQuery hook for any third party logic to be applied before execution.
-        const { sql: updatedSQL, params: updatedParams } = await beforeQuery(sql, params, dataSource, config)
-
-        // If the query was modified by RLS then we determine it isn't currently a valid candidate
-        // for caching. In the future we will support queries impacted by RLS and caching their
-        // results.
-        if (!isRaw) {
-            // If a cached version of this query request exists, this function will fetch the cached results.
-            const cache = await beforeQueryCache(updatedSQL, updatedParams, dataSource, config?.externalDbType)
-            if (cache) {
-                return cache
-            }
-        }
-
-        let response;
-
-        if (dataSource.source === 'internal') {
-            response = await dataSource.internalConnection?.durableObject.executeQuery(updatedSQL, updatedParams, isRaw);
-        } else {
-            response = await executeExternalQuery(updatedSQL, updatedParams, isRaw, dataSource, config);
-        }
-
-        // If this is a cacheable query, this function will handle that logic.
-        if (!isRaw) {
-            await afterQueryCache(sql, updatedParams, response, dataSource)
-        }
-
-        return await afterQuery(updatedSQL, response, isRaw, dataSource, config);
-    } catch (error: any) {
-        throw new Error(error.message ?? 'An error occurred');
-    }
-}
-
-export async function executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, dataSource?: DataSource, config?: HandlerConfig): Promise<QueryResponse> {
-    if (!dataSource) {
-        console.error('Data source not found.')
-        return []
-    }
-    
-    const results = [];
-
-    for (const query of queries) {
-        const result = await executeQuery(query.sql, query.params, isRaw, dataSource, config);
-        results.push(result);
-    }
-    
-    return results;
-}
-
-async function createSDKPostgresConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new PostgreSQLConnection(
-        new PgClient({
-            host: config.externalDbHost,
-            port: Number(config.externalDbPort),
-            user: config.externalDbUser,
-            password: config.externalDbPassword,
-            database: config.externalDbName,
-        })
+  try {
+    // If the allowlist feature is enabled, we should verify the query is allowed before proceeding.
+    await isQueryAllowed(
+      sql,
+      config?.features?.allowlist ?? false,
+      dataSource,
+      config
     );
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbDefaultSchema || 'public'
-    }
-}
-
-async function createSDKMySQLConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new MySQLConnection(
-        createMySqlConnection({
-            host: config.externalDbHost,
-            port: Number(config.externalDbPort),
-            user: config.externalDbUser,
-            password: config.externalDbPassword,
-            database: config.externalDbName,
-        })
+    // If the row level security feature is enabled, we should apply our policies to this SQL statement.
+    sql = await applyRLS(
+      sql,
+      config?.features?.rls ?? false,
+      dataSource.external?.dialect,
+      dataSource,
+      config
     );
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbDefaultSchema || 'public'
-    }
-}
-
-async function createSDKMongoConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new MongoDBConnection(
-        new MongoClient(config.externalDbMongodbUri as string),
-        config.externalDbName as string
+    // Run the beforeQuery hook for any third party logic to be applied before execution.
+    const { sql: updatedSQL, params: updatedParams } = await beforeQuery(
+      sql,
+      params,
+      dataSource,
+      config
     );
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbName || ''
+    // If the query was modified by RLS then we determine it isn't currently a valid candidate
+    // for caching. In the future we will support queries impacted by RLS and caching their
+    // results.
+    if (!isRaw) {
+      // If a cached version of this query request exists, this function will fetch the cached results.
+      const cache = await beforeQueryCache({
+        sql: updatedSQL,
+        params: updatedParams,
+        dataSource,
+      });
+      
+      if (cache) {
+        return cache;
+      }
     }
+
+    let response;
+
+    if (dataSource.source === "internal") {
+      response = await dataSource.rpc.executeQuery({
+        sql: updatedSQL,
+        params: updatedParams,
+        isRaw,
+      });
+    } else {
+      response = await executeExternalQuery(
+        updatedSQL,
+        updatedParams,
+        isRaw,
+        dataSource,
+        config
+      );
+    }
+
+    // If this is a cacheable query, this function will handle that logic.
+    if (!isRaw) {
+      await afterQueryCache(sql, updatedParams, response, dataSource);
+    }
+
+    return await afterQuery(updatedSQL, response, isRaw, dataSource, config);
+  } catch (error: any) {
+    throw new Error(error.message ?? "An error occurred");
+  }
 }
 
-async function createSDKTursoConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new TursoConnection(createTursoConnection({ 
-        url: config.externalDbTursoUri || '',
-        authToken: config.externalDbTursoToken || ''
-    }));
+export async function executeTransaction(
+  queries: { sql: string; params?: any[] }[],
+  isRaw: boolean,
+  dataSource?: DataSource,
+  config?: StarbaseDBConfiguration
+): Promise<QueryResponse> {
+  if (!dataSource) {
+    console.error("Data source not found.");
+    return [];
+  }
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbDefaultSchema || 'main'
-    }
+  const results = [];
+
+  for (const query of queries) {
+    const result = await executeQuery(
+      query.sql,
+      query.params,
+      isRaw,
+      dataSource,
+      config
+    );
+    results.push(result);
+  }
+
+  return results;
 }
 
-async function createSDKCloudflareConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new CloudflareD1Connection({
-        apiKey: config.externalDbCloudflareApiKey as string,
-        accountId: config.externalDbCloudflareAccountId as string,
-        databaseId: config.externalDbCloudflareDatabaseId as string,
-    });
+async function createSDKPostgresConnection(
+  source: RemoteSource
+): Promise<ConnectionDetails> {
+  const client = new PostgreSQLConnection(
+    new PgClient({
+      host: source.host,
+      port: source.port,
+      user: source.user,
+      password: source.password,
+      database: source.database,
+    })
+  );
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbDefaultSchema || 'main'
-    }
+  return {
+    database: client,
+    defaultSchema: source.defaultSchema || "public",
+  };
 }
 
-async function createSDKStarbaseConnection(config: HandlerConfig): Promise<ConnectionDetails> {
-    const client = new StarbaseConnection({
-        apiKey: config.externalDbStarbaseUri as string,
-        url: config.externalDbStarbaseToken as string,
-    });
+async function createSDKMySQLConnection(
+  source: RemoteSource
+): Promise<ConnectionDetails> {
+  const client = new MySQLConnection(
+    createMySqlConnection({
+      host: source.host,
+      port: source.port,
+      user: source.user,
+      password: source.password,
+      database: source.database,
+    })
+  );
 
-    return {
-        database: client,
-        defaultSchema: config.externalDbDefaultSchema || 'main'
-    }
+  return {
+    database: client,
+    defaultSchema: source.defaultSchema || "public",
+  };
 }
 
-export async function executeSDKQuery(sql: string, params: any | undefined, isRaw: boolean, dataSource?: DataSource, config?: HandlerConfig): Promise<QueryResponse> {
-    if (!dataSource) {
-        console.error('Data source not found.')
-        return []
-    }
-    
-    // Initialize connection if it doesn't exist
-    if (!globalConnection) {
-        if (config?.externalDbType === 'postgres') {
-            const { database } = await createSDKPostgresConnection(config)
-            globalConnection = database;
-        } else if (config?.externalDbType === 'mysql' && config) {
-            const { database } = await createSDKMySQLConnection(config)
-            globalConnection = database;
-        } else if (config?.externalDbType === 'mongo' && config) {
-            const { database } = await createSDKMongoConnection(config)
-            globalConnection = database;
-        } else if (config?.externalDbType === 'sqlite' && config?.externalDbCloudflareApiKey && config) {
-            const { database } = await createSDKCloudflareConnection(config)
-            globalConnection = database;
-        } else if (config?.externalDbType === 'sqlite' && config?.externalDbStarbaseUri && config) {
-            const { database } = await createSDKStarbaseConnection(config)
-            globalConnection = database;
-        } else if (config?.externalDbType === 'sqlite' && config?.externalDbTursoUri && config) {
-            const { database } = await createSDKTursoConnection(config)
-            globalConnection = database;
-        }
-        
-        await globalConnection.connect();
-    }
+// async function createSDKMongoConnection(
+//   config: StarbaseDBConfiguration
+// ): Promise<ConnectionDetails> {
+//   const client = new MongoDBConnection(
+//     new MongoClient(config.externalDbMongodbUri as string),
+//     config.externalDbName as string
+//   );
 
-    const { data } = await globalConnection.raw(sql, params);
-    return data;
+//   return {
+//     database: client,
+//     defaultSchema: config.externalDbName || "",
+//   };
+// }
+
+async function createSDKTursoConnection(
+  source: TursoDBSource
+): Promise<ConnectionDetails> {
+  const client = new TursoConnection(
+    createTursoConnection({
+      url: source.uri,
+      authToken: source.token,
+    })
+  );
+
+  return {
+    database: client,
+    defaultSchema: source.defaultSchema || "main",
+  };
+}
+
+async function createSDKCloudflareConnection(
+  source: CloudflareD1Source
+): Promise<ConnectionDetails> {
+  const client = new CloudflareD1Connection({
+    apiKey: source.apiKey,
+    accountId: source.accountId,
+    databaseId: source.databaseId,
+  });
+
+  return {
+    database: client,
+    defaultSchema: source.defaultSchema || "main",
+  };
+}
+
+async function createSDKStarbaseConnection(
+  source: StarbaseDBSource
+): Promise<ConnectionDetails> {
+  const client = new StarbaseConnection({
+    apiKey: source.apiKey,
+    url: source.token,
+  });
+
+  return {
+    database: client,
+    defaultSchema: source.defaultSchema || "main",
+  };
+}
+
+export async function executeSDKQuery(opts: {
+  sql: string;
+  params?: unknown[] | undefined;
+  dataSource: DataSource;
+  config: StarbaseDBConfiguration;
+}) {
+  const external = opts.dataSource.external;
+
+  if (!external) {
+    console.warn("No external connection found");
+    return [];
+  }
+
+  let connection;
+
+  if (external.dialect === "postgres") {
+    const { database } = await createSDKPostgresConnection(external);
+    connection = database;
+  } else if (external.dialect === "mysql") {
+    const { database } = await createSDKMySQLConnection(external);
+    connection = database;
+  } else if (external.provider === "cloudflare-d1") {
+    const { database } = await createSDKCloudflareConnection(external);
+    connection = database;
+  } else if (external.provider === "starbase") {
+    const { database } = await createSDKStarbaseConnection(external);
+    connection = database;
+  } else if (external.provider === "turso") {
+    const { database } = await createSDKTursoConnection(external);
+    connection = database;
+  } else {
+    throw new Error("Unsupported external database type");
+  }
+
+  await connection.connect();
+
+  const { data } = await connection.raw(opts.sql, opts.params);
+  return data;
 }

--- a/src/rls/index.ts
+++ b/src/rls/index.ts
@@ -1,5 +1,5 @@
 import { StarbaseDBConfiguration } from "../handler";
-import { DataSource } from "../types";
+import { DataSource, QueryResult } from "../types";
 
 const parser = new (require("node-sql-parser").Parser)();
 
@@ -53,7 +53,7 @@ async function loadPolicies(dataSource: DataSource): Promise<Policy[]> {
       'SELECT "actions", "schema", "table", "column", "value", "value_type", "operator" FROM tmp_rls_policies';
     const result = await dataSource.rpc.executeQuery({
       sql: statement,
-    });
+    }) as QueryResult[];
 
     if (!result || result.length === 0) {
       // Discussion point to be had here. For safety precautions I am ejecting

--- a/src/rls/index.ts
+++ b/src/rls/index.ts
@@ -1,31 +1,31 @@
-import { HandlerConfig } from "../handler";
-import { DataSource, Source } from "../types";
+import { StarbaseDBConfiguration } from "../handler";
+import { DataSource } from "../types";
 
-const parser = new (require('node-sql-parser').Parser)();
+const parser = new (require("node-sql-parser").Parser)();
 
 type Policy = {
-    action: string;
-    condition: {
-        type: string;
-        operator: string;
-        left: {
-            type: string;
-            table: string;
-            column: string;
-        };
-        right: {
-            type: string;
-            value: string;
-        }
-    }
-}
+  action: string;
+  condition: {
+    type: string;
+    operator: string;
+    left: {
+      type: string;
+      table: string;
+      column: string;
+    };
+    right: {
+      type: string;
+      value: string;
+    };
+  };
+};
 
 let policies: Policy[] = [];
 
 // Rules on how RLS policies should work
 // 1. If a table has _any_ rules applied to it, then each action needs to be explicitly defined or it should be automatically denied.
-    // For example, if I say "SELECT" on table "todos" has an RLS policy but no entry for "INSERT" then insert statements should fail.
-    // This is the equivalent of turning "on" RLS for a particular table.
+// For example, if I say "SELECT" on table "todos" has an RLS policy but no entry for "INSERT" then insert statements should fail.
+// This is the equivalent of turning "on" RLS for a particular table.
 // 2. For any actions of type "SELECT" we want to inject an additional WHERE clause wrapped in `(...)` which prevents overriding like `1=1`
 
 // ----------
@@ -33,316 +33,340 @@ let policies: Policy[] = [];
 // Things to consider:
 // 1. Do we need to always check `schema`.`table` instead of just `table` or whatever is entered in our policy table?
 // 2. Perhaps we should automatically throw an error if there is an error querying (or zero results return) from the policy table?
-    // -> I say this because if an error occurs then it would entirely circumvent rules and over-expose data. 
-    // -> If they really don't want any rules to exist, remove this power-up
+// -> I say this because if an error occurs then it would entirely circumvent rules and over-expose data.
+// -> If they really don't want any rules to exist, remove this power-up
 
 function normalizeIdentifier(name: string): string {
-    if (!name) return name;
-    if ((name.startsWith('"') && name.endsWith('"')) ||
-        (name.startsWith('`') && name.endsWith('`'))) {
-        return name.slice(1, -1);
-    }
-    return name;
+  if (!name) return name;
+  if (
+    (name.startsWith('"') && name.endsWith('"')) ||
+    (name.startsWith("`") && name.endsWith("`"))
+  ) {
+    return name.slice(1, -1);
+  }
+  return name;
 }
 
-async function loadPolicies(dataSource?: DataSource): Promise<Policy[]> {
-    try {
-        const statement = 'SELECT "actions", "schema", "table", "column", "value", "value_type", "operator" FROM tmp_rls_policies'
-        const result = await dataSource?.internalConnection?.durableObject.executeQuery(statement, [], false) as any[];
+async function loadPolicies(dataSource: DataSource): Promise<Policy[]> {
+  try {
+    const statement =
+      'SELECT "actions", "schema", "table", "column", "value", "value_type", "operator" FROM tmp_rls_policies';
+    const result = await dataSource.rpc.executeQuery({
+      sql: statement,
+    });
 
-        if (!result || result.length === 0) {
-            // Discussion point to be had here. For safety precautions I am ejecting
-            // out of the entire flow if no results are responded back with for example
-            // the case where the database instance is not responding, we don't want to 
-            // simply assume that the incoming SQL should be processed. Instead, we need
-            // to know that we received all the rules for us to enforce them. When no rules
-            // exist we exit with an error.
-            throw new Error("Error fetching RLS policies. No policies may exist or there was an error fetching.");
-        }
-
-        const policies = result.map((row: any) => {
-            let value = row.value;
-            const valueType = row.value_type?.toLowerCase();
-
-            // Currently we are supporting two `value_type` options for the time being. By
-            // default values are assumed as `string` unless the type is expressed as another
-            // in which we cast it to that type. We will need to handle scenarios where
-            // the SQL statement itself will need the type casting.
-            if (valueType === 'number') {
-                value = Number(value);
-
-                // For example, some databases may require casting like the commented out
-                // string here below. We will want to come back and help cover those
-                // particular situations.
-                // value = `${value}::INT`
-            }
-            
-            let tableName = row.schema ? `${row.schema}.${row.table}` : row.table;
-            tableName = normalizeIdentifier(tableName);
-            const columnName = normalizeIdentifier(row.column);
-
-            // If the policy value is context.id(), use a placeholder
-            let rightNode;
-            if (value === 'context.id()') {
-                rightNode = { type: 'string', value: '__CONTEXT_ID__' };
-            } else {
-                rightNode = { type: 'string', value: value };
-            }
-
-            // This policy will help construct clauses, such as a WHERE, for the criteria to be met.
-            // For example the left side equals the qualifier table column and the right side equals
-            // the value that column should be set to. So a basic example could be:
-            // `WHERE (my_column = '1234')`
-            return {
-                action: row.actions.toUpperCase(),
-                condition: {
-                    type: 'binary_expr',
-                    operator: row.operator,
-                    left: { type: 'column_ref', table: tableName, column: columnName },
-                    right: rightNode
-                }
-            };
-        });
-
-        return policies;
-    } catch (error) {
-        console.error('Error loading RLS policies:', error);
-        return [];
+    if (!result || result.length === 0) {
+      // Discussion point to be had here. For safety precautions I am ejecting
+      // out of the entire flow if no results are responded back with for example
+      // the case where the database instance is not responding, we don't want to
+      // simply assume that the incoming SQL should be processed. Instead, we need
+      // to know that we received all the rules for us to enforce them. When no rules
+      // exist we exit with an error.
+      throw new Error(
+        "Error fetching RLS policies. No policies may exist or there was an error fetching."
+      );
     }
+
+    const policies = result.map((row: any) => {
+      let value = row.value;
+      const valueType = row.value_type?.toLowerCase();
+
+      // Currently we are supporting two `value_type` options for the time being. By
+      // default values are assumed as `string` unless the type is expressed as another
+      // in which we cast it to that type. We will need to handle scenarios where
+      // the SQL statement itself will need the type casting.
+      if (valueType === "number") {
+        value = Number(value);
+
+        // For example, some databases may require casting like the commented out
+        // string here below. We will want to come back and help cover those
+        // particular situations.
+        // value = `${value}::INT`
+      }
+
+      let tableName = row.schema ? `${row.schema}.${row.table}` : row.table;
+      tableName = normalizeIdentifier(tableName);
+      const columnName = normalizeIdentifier(row.column);
+
+      // If the policy value is context.id(), use a placeholder
+      let rightNode;
+      if (value === "context.id()") {
+        rightNode = { type: "string", value: "__CONTEXT_ID__" };
+      } else {
+        rightNode = { type: "string", value: value };
+      }
+
+      // This policy will help construct clauses, such as a WHERE, for the criteria to be met.
+      // For example the left side equals the qualifier table column and the right side equals
+      // the value that column should be set to. So a basic example could be:
+      // `WHERE (my_column = '1234')`
+      return {
+        action: row.actions.toUpperCase(),
+        condition: {
+          type: "binary_expr",
+          operator: row.operator,
+          left: { type: "column_ref", table: tableName, column: columnName },
+          right: rightNode,
+        },
+      };
+    });
+
+    return policies;
+  } catch (error) {
+    console.error("Error loading RLS policies:", error);
+    return [];
+  }
 }
 
-export async function applyRLS(sql: string, isEnabled: boolean, dialect?: string, dataSource?: DataSource, config?: HandlerConfig): Promise<string> {
-    if (!isEnabled) return sql;
-    if (!sql) {
-        throw Error('No SQL query found in RLS plugin.')
+export async function applyRLS(
+  sql: string,
+  isEnabled: boolean,
+  dataSource: DataSource,
+  config: StarbaseDBConfiguration
+): Promise<string> {
+  if (!isEnabled) return sql;
+  if (!sql) {
+    throw Error("No SQL query found in RLS plugin.");
+  }
+
+  // Do not apply RLS rules to the admin user
+  if (config.role === "admin") {
+    return sql;
+  }
+
+  policies = await loadPolicies(dataSource);
+
+  const dialect =
+    dataSource.source === "external" ? dataSource.external!.dialect : "sqlite";
+
+  let context: Record<string, any> = dataSource?.context ?? {};
+  let ast;
+  let modifiedSql;
+  const sqlifyOptions = {
+    database: dialect,
+    quote: "",
+  };
+
+  // We are originally provided a SQL statement to evaluate. The first task we must
+  // complete is converting it from SQL to an AST object we can breakdown and
+  // understand the structure. By breaking down the structure this is where we can
+  // begin applying our RLS policies by injecting items into the abstract syntax
+  // tree which will later be converted back to an executable SQL statement.
+  try {
+    ast = parser.astify(sql, { database: dialect });
+    if (Array.isArray(ast)) {
+      ast.forEach((singleAst) => applyRLSToAst(singleAst));
+    } else {
+      applyRLSToAst(ast);
     }
+  } catch (error) {
+    console.error("Error parsing SQL:", error);
+    throw error as Error;
+  }
 
-    // Do not apply RLS rules to the admin user
-    if (dataSource?.request.headers.get('Authorization') === `Bearer ${config?.adminAuthorizationToken}`) {
-        return sql;
+  // After the query was converted into an AST and had any RLS policy rules
+  // injected into the abstract syntax tree dynamically, now we are ready to
+  // convert the AST object back into a SQL statement that the database can
+  // execute.
+  try {
+    if (Array.isArray(ast)) {
+      modifiedSql = ast
+        .map((singleAst) => parser.sqlify(singleAst, sqlifyOptions))
+        .join("; ");
+    } else {
+      modifiedSql = parser.sqlify(ast, sqlifyOptions);
     }
+  } catch (error) {
+    console.error("Error generating SQL from AST:", error);
+    throw error as Error;
+  }
 
-    policies = await loadPolicies(dataSource);
+  // Replace placeholder with the user's ID properly quoted
+  if (context?.sub) {
+    modifiedSql = modifiedSql.replace(/'__CONTEXT_ID__'/g, `'${context.sub}'`);
+  }
 
-    if (!dialect || dataSource?.source === Source.internal) dialect = 'sqlite'
-    if (dialect.toLowerCase() === 'postgres') dialect = 'postgresql'
-
-    let context: Record<string, any> = dataSource?.context ?? {}
-    let ast;
-    let modifiedSql;
-    const sqlifyOptions = {
-        database: dialect,
-        quote: ''
-    };
-
-    // We are originally provided a SQL statement to evaluate. The first task we must
-    // complete is converting it from SQL to an AST object we can breakdown and 
-    // understand the structure. By breaking down the structure this is where we can
-    // begin applying our RLS policies by injecting items into the abstract syntax
-    // tree which will later be converted back to an executable SQL statement.
-    try {
-        ast = parser.astify(sql, { database: dialect });
-        if (Array.isArray(ast)) {
-            ast.forEach(singleAst => applyRLSToAst(singleAst));
-        } else {
-            applyRLSToAst(ast);
-        }
-    } catch (error) {
-        console.error('Error parsing SQL:', error);
-        throw error as Error;
-    }
-
-    // After the query was converted into an AST and had any RLS policy rules
-    // injected into the abstract syntax tree dynamically, now we are ready to
-    // convert the AST object back into a SQL statement that the database can
-    // execute.
-    try {
-        if (Array.isArray(ast)) {
-            modifiedSql = ast.map(singleAst => parser.sqlify(singleAst, sqlifyOptions)).join('; ');
-        } else {
-            modifiedSql = parser.sqlify(ast, sqlifyOptions);
-        }
-    } catch (error) {
-        console.error('Error generating SQL from AST:', error);
-        throw error as Error;
-    }
-
-    // Replace placeholder with the user's ID properly quoted
-    if (context?.sub) {
-        modifiedSql = modifiedSql.replace(/'__CONTEXT_ID__'/g, `'${context.sub}'`);
-    }
-
-    return modifiedSql;
+  return modifiedSql;
 }
 
 function applyRLSToAst(ast: any): void {
-    if (!ast) return;
+  if (!ast) return;
 
-    // Handle WITH (CTE) queries as arrays
-    if (ast.with && Array.isArray(ast.with)) {
-        for (const cte of ast.with) {
-            if (cte.stmt) {
-                applyRLSToAst(cte.stmt);
-            }
-        }
+  // Handle WITH (CTE) queries as arrays
+  if (ast.with && Array.isArray(ast.with)) {
+    for (const cte of ast.with) {
+      if (cte.stmt) {
+        applyRLSToAst(cte.stmt);
+      }
     }
+  }
 
-    // Set operations
-    if (['union', 'intersect', 'except'].includes(ast.type)) {
-        applyRLSToAst(ast.left);
-        applyRLSToAst(ast.right);
-        return;
-    }
+  // Set operations
+  if (["union", "intersect", "except"].includes(ast.type)) {
+    applyRLSToAst(ast.left);
+    applyRLSToAst(ast.right);
+    return;
+  }
 
-    // Subqueries in INSERT/UPDATE/DELETE
-    if (ast.type === 'insert' && ast.from) {
-        applyRLSToAst(ast.from);
-    }
-    if (ast.type === 'update' && ast.where) {
-        traverseWhere(ast.where);
-    }
-    if (ast.type === 'delete' && ast.where) {
-        traverseWhere(ast.where);
-    }
+  // Subqueries in INSERT/UPDATE/DELETE
+  if (ast.type === "insert" && ast.from) {
+    applyRLSToAst(ast.from);
+  }
+  if (ast.type === "update" && ast.where) {
+    traverseWhere(ast.where);
+  }
+  if (ast.type === "delete" && ast.where) {
+    traverseWhere(ast.where);
+  }
 
-    const tablesWithRules: Record<string, string[]> = {}
-    policies.forEach(policy => {
-        const tbl = normalizeIdentifier(policy.condition.left.table);
-        if (!tablesWithRules[tbl]) {
-            tablesWithRules[tbl] = [];
-        }
-        tablesWithRules[tbl].push(policy.action);
+  const tablesWithRules: Record<string, string[]> = {};
+  policies.forEach((policy) => {
+    const tbl = normalizeIdentifier(policy.condition.left.table);
+    if (!tablesWithRules[tbl]) {
+      tablesWithRules[tbl] = [];
+    }
+    tablesWithRules[tbl].push(policy.action);
+  });
+
+  const statementType = ast.type?.toUpperCase();
+  if (!["SELECT", "UPDATE", "DELETE", "INSERT"].includes(statementType)) {
+    return;
+  }
+
+  let tables: string[] = [];
+  if (statementType === "INSERT") {
+    let tableName = normalizeIdentifier(ast.table[0].table);
+    if (tableName.includes(".")) {
+      tableName = tableName.split(".")[1];
+    }
+    tables = [tableName];
+  } else if (statementType === "UPDATE") {
+    tables = ast.table.map((tableRef: any) => {
+      let tableName = normalizeIdentifier(tableRef.table);
+      if (tableName.includes(".")) {
+        tableName = tableName.split(".")[1];
+      }
+      return tableName;
     });
-
-    const statementType = ast.type?.toUpperCase();
-    if (!['SELECT', 'UPDATE', 'DELETE', 'INSERT'].includes(statementType)) {
-        return;
-    }
-
-    let tables: string[] = [];
-    if (statementType === 'INSERT') {
-        let tableName = normalizeIdentifier(ast.table[0].table);
-        if (tableName.includes('.')) {
-            tableName = tableName.split('.')[1];
+  } else {
+    // SELECT or DELETE
+    tables =
+      ast.from?.map((fromTable: any) => {
+        let tableName = normalizeIdentifier(fromTable.table);
+        if (tableName.includes(".")) {
+          tableName = tableName.split(".")[1];
         }
-        tables = [tableName];
-    } else if (statementType === 'UPDATE') {
-        tables = ast.table.map((tableRef: any) => {
-            let tableName = normalizeIdentifier(tableRef.table);
-            if (tableName.includes('.')) {
-                tableName = tableName.split('.')[1];
-            }
-            return tableName;
-        });
-    } else {
-        // SELECT or DELETE
-        tables = ast.from?.map((fromTable: any) => {
-            let tableName = normalizeIdentifier(fromTable.table);
-            if (tableName.includes('.')) {
-                tableName = tableName.split('.')[1];
-            }
-            return tableName;
-        }) || [];
+        return tableName;
+      }) || [];
+  }
+
+  const restrictedTables = Object.keys(tablesWithRules);
+
+  for (const table of tables) {
+    if (restrictedTables.includes(table)) {
+      const allowedActions = tablesWithRules[table];
+      if (!allowedActions.includes(statementType)) {
+        throw new Error(
+          `Unauthorized access: No matching rules for ${statementType} on restricted table ${table}`
+        );
+      }
     }
+  }
 
-    const restrictedTables = Object.keys(tablesWithRules);
+  policies
+    .filter(
+      (policy) => policy.action === statementType || policy.action === "*"
+    )
+    .forEach(({ action, condition }) => {
+      const targetTable = normalizeIdentifier(condition.left.table);
+      const isTargetTable = tables.includes(targetTable);
 
-    for (const table of tables) {
-        if (restrictedTables.includes(table)) {
-            const allowedActions = tablesWithRules[table];
-            if (!allowedActions.includes(statementType)) {
-                throw new Error(`Unauthorized access: No matching rules for ${statementType} on restricted table ${table}`);
-            }
+      if (!isTargetTable) return;
+
+      if (action !== "INSERT") {
+        // Add condition to WHERE with parentheses
+        if (ast.where) {
+          ast.where = {
+            type: "binary_expr",
+            operator: "AND",
+            parentheses: true,
+            left: {
+              ...ast.where,
+              parentheses: true,
+            },
+            right: {
+              ...condition,
+              parentheses: true,
+            },
+          };
+        } else {
+          ast.where = {
+            ...condition,
+            parentheses: true,
+          };
         }
-    }
-
-    policies
-        .filter(policy => policy.action === statementType || policy.action === '*')
-        .forEach(({ action, condition }) => {
-            const targetTable = normalizeIdentifier(condition.left.table);
-            const isTargetTable = tables.includes(targetTable);
-
-            if (!isTargetTable) return;
-
-            if (action !== 'INSERT') {
-                // Add condition to WHERE with parentheses
-                if (ast.where) {
-                    ast.where = {
-                        type: 'binary_expr',
-                        operator: 'AND',
-                        parentheses: true,
-                        left: {
-                            ...ast.where,
-                            parentheses: true
-                        },
-                        right: {
-                            ...condition,
-                            parentheses: true
-                        }
-                    };
-                } else {
-                    ast.where = {
-                        ...condition,
-                        parentheses: true
-                    };
-                }
-            } else {
-                // For INSERT, enforce column values
-                if (ast.values && ast.values.length > 0) {
-                    const columnIndex = ast.columns.findIndex((col: any) => 
-                        normalizeIdentifier(col) === normalizeIdentifier(condition.left.column)
-                    );
-                    if (columnIndex !== -1) {
-                        ast.values.forEach((valueList: any) => {
-                            if (valueList.type === 'expr_list' && Array.isArray(valueList.value)) {
-                                valueList.value[columnIndex] = {
-                                    type: condition.right.type,
-                                    value: condition.right.value
-                                };
-                            } else {
-                                valueList[columnIndex] = {
-                                    type: condition.right.type,
-                                    value: condition.right.value
-                                };
-                            }
-                        });
-                    }
-                }
-            }
-        });
-
-    ast.from?.forEach((fromItem: any) => {
-        if (fromItem.expr && fromItem.expr.type === 'select') {
-            applyRLSToAst(fromItem.expr);
-        }
-        
-        // Handle both single join and array of joins
-        if (fromItem.join) {
-            const joins = Array.isArray(fromItem.join) ? fromItem.join : [fromItem];
-            joins.forEach((joinItem: any) => {
-                if (joinItem.expr && joinItem.expr.type === 'select') {
-                    applyRLSToAst(joinItem.expr);
-                }
+      } else {
+        // For INSERT, enforce column values
+        if (ast.values && ast.values.length > 0) {
+          const columnIndex = ast.columns.findIndex(
+            (col: any) =>
+              normalizeIdentifier(col) ===
+              normalizeIdentifier(condition.left.column)
+          );
+          if (columnIndex !== -1) {
+            ast.values.forEach((valueList: any) => {
+              if (
+                valueList.type === "expr_list" &&
+                Array.isArray(valueList.value)
+              ) {
+                valueList.value[columnIndex] = {
+                  type: condition.right.type,
+                  value: condition.right.value,
+                };
+              } else {
+                valueList[columnIndex] = {
+                  type: condition.right.type,
+                  value: condition.right.value,
+                };
+              }
             });
+          }
         }
+      }
     });
 
-    if (ast.where) {
-        traverseWhere(ast.where);
+  ast.from?.forEach((fromItem: any) => {
+    if (fromItem.expr && fromItem.expr.type === "select") {
+      applyRLSToAst(fromItem.expr);
     }
 
-    ast.columns?.forEach((column: any) => {
-        if (column.expr && column.expr.type === 'select') {
-            applyRLSToAst(column.expr);
+    // Handle both single join and array of joins
+    if (fromItem.join) {
+      const joins = Array.isArray(fromItem.join) ? fromItem.join : [fromItem];
+      joins.forEach((joinItem: any) => {
+        if (joinItem.expr && joinItem.expr.type === "select") {
+          applyRLSToAst(joinItem.expr);
         }
-    });
+      });
+    }
+  });
+
+  if (ast.where) {
+    traverseWhere(ast.where);
+  }
+
+  ast.columns?.forEach((column: any) => {
+    if (column.expr && column.expr.type === "select") {
+      applyRLSToAst(column.expr);
+    }
+  });
 }
 
 function traverseWhere(node: any): void {
-    if (!node) return;
-    if (node.type === 'select') {
-        applyRLSToAst(node);
-    }
-    if (node.left) traverseWhere(node.left);
-    if (node.right) traverseWhere(node.right);
+  if (!node) return;
+  if (node.type === "select") {
+    applyRLSToAst(node);
+  }
+  if (node.left) traverseWhere(node.left);
+  if (node.right) traverseWhere(node.right);
 }

--- a/src/rls/index.ts
+++ b/src/rls/index.ts
@@ -118,12 +118,14 @@ async function loadPolicies(dataSource: DataSource): Promise<Policy[]> {
   }
 }
 
-export async function applyRLS(
-  sql: string,
-  isEnabled: boolean,
-  dataSource: DataSource,
-  config: StarbaseDBConfiguration
-): Promise<string> {
+export async function applyRLS(opts: {
+  sql: string;
+  isEnabled: boolean;
+  dataSource: DataSource;
+  config: StarbaseDBConfiguration;
+}): Promise<string> {
+  const { sql, isEnabled, dataSource, config } = opts;
+
   if (!isEnabled) return sql;
   if (!sql) {
     throw Error("No SQL query found in RLS plugin.");

--- a/src/studio/index.ts
+++ b/src/studio/index.ts
@@ -1,10 +1,10 @@
 interface HandleStudioRequestOption {
     username: string,
     password: string,
-    // apiToken: string;
+    apiKey: string;
 }
 
-function createStudioHTML(apiToken: string): string {
+function createStudioHTML(apiKey: string): string {
     return `<!doctype>
 <html>
 <head>
@@ -38,7 +38,7 @@ function createStudioHTML(apiToken: string): string {
             method: "post",
             headers: {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer ${apiToken}"
+                "Authorization": "Bearer ${apiKey}"
             },
             body: JSON.stringify(requestBody)
         }).then(r => {
@@ -115,7 +115,7 @@ function createStudioHTML(apiToken: string): string {
 </html>`
 }
 
-export default async function handleStudioRequest(request: Request, options: HandleStudioRequestOption): Promise<Response> {
+export async function handleStudioRequest(request: Request, options: HandleStudioRequestOption): Promise<Response> {
     // Check for basic authorization
     const auth = request.headers.get('Authorization');
 
@@ -143,7 +143,7 @@ export default async function handleStudioRequest(request: Request, options: Han
     }
 
     // Proceed with the request
-    return new Response(createStudioHTML(options.apiToken), {
+    return new Response(createStudioHTML(options.apiKey), {
         headers: { 'Content-Type': 'text/html' }
     });
 }

--- a/src/studio/index.ts
+++ b/src/studio/index.ts
@@ -1,7 +1,7 @@
 interface HandleStudioRequestOption {
     username: string,
     password: string,
-    apiToken: string;
+    // apiToken: string;
 }
 
 function createStudioHTML(apiToken: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,23 +57,6 @@ export type DataSource = {
   cacheTTL?: number;
 };
 
-// export interface InternalConnection {
-//   durableObject: DatabaseStub;
-// }
-
-// export type DatabaseStub = DurableObjectStub & {
-//   fetch: (init?: RequestInit | Request) => Promise<Response>;
-//   executeQuery(
-//     sql: string,
-//     params: any[] | undefined,
-//     isRaw: boolean
-//   ): QueryResponse;
-//   executeTransaction(
-//     queries: { sql: string; params?: any[] }[],
-//     isRaw: boolean
-//   ): any[];
-// };
-
 export enum RegionLocationHint {
   AUTO = "auto",
   WNAM = "wnam", // Western North America

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { StarbaseDBDurableObject } from "./do";
-import { QueryResponse } from "./operation";
 
 export type QueryResult = Record<string, SqlStorageValue>;
 
@@ -45,7 +44,6 @@ export type TursoDBSource = {
 export type ExternalDatabaseSource =
   | PostgresSource
   | MySQLSource
-  // | MongoSource
   | CloudflareD1Source
   | StarbaseDBSource
   | TursoDBSource;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type RemoteSource = {
 };
 
 export type PostgresSource = {
-  dialect: "postgres";
+  dialect: "postgresql";
 } & RemoteSource;
 
 export type MySQLSource = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,39 +1,90 @@
+import { StarbaseDBDurableObject } from "./do";
 import { QueryResponse } from "./operation";
 
-export enum Source {
-    internal = 'internal',  // Durable Object's SQLite instance
-    external = 'external'   // External data source (e.g. Outerbase)
-}
+export type QueryResult = Record<string, SqlStorageValue>;
 
-export type DataSource = {
-    source: Source;
-    request: Request;
-    internalConnection?: InternalConnection;
-    externalConnection?: {
-        outerbaseApiKey: string;
-    };
-    context?: Record<string, any>;
-}
-
-export interface InternalConnection {
-    durableObject: DatabaseStub;
-}
-
-export type DatabaseStub = DurableObjectStub & {
-    fetch: (init?: RequestInit | Request) => Promise<Response>;
-    executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
-    executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[];
+export type RemoteSource = {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  defaultSchema?: string;
 };
 
+export type PostgresSource = {
+  dialect: "postgres";
+} & RemoteSource;
+
+export type MySQLSource = {
+  dialect: "mysql";
+} & RemoteSource;
+
+export type CloudflareD1Source = {
+  dialect: "sqlite";
+  provider: "cloudflare-d1";
+  apiKey: string;
+  accountId: string;
+  databaseId: string;
+} & Pick<RemoteSource, "defaultSchema">;
+
+export type StarbaseDBSource = {
+  dialect: "sqlite";
+  provider: "starbase";
+  apiKey: string;
+  token: string;
+} & Pick<RemoteSource, "defaultSchema">;
+
+export type TursoDBSource = {
+  dialect: "sqlite";
+  provider: "turso";
+  uri: string;
+  token: string;
+} & Pick<RemoteSource, "defaultSchema">;
+
+export type ExternalDatabaseSource =
+  | PostgresSource
+  | MySQLSource
+  // | MongoSource
+  | CloudflareD1Source
+  | StarbaseDBSource
+  | TursoDBSource;
+
+export type DataSource = {
+  rpc: Awaited<ReturnType<DurableObjectStub<StarbaseDBDurableObject>["init"]>>;
+  source: "internal" | "external";
+  external?: ExternalDatabaseSource;
+  context?: Record<string, unknown>;
+  cache?: boolean;
+  cacheTTL?: number;
+};
+
+// export interface InternalConnection {
+//   durableObject: DatabaseStub;
+// }
+
+// export type DatabaseStub = DurableObjectStub & {
+//   fetch: (init?: RequestInit | Request) => Promise<Response>;
+//   executeQuery(
+//     sql: string,
+//     params: any[] | undefined,
+//     isRaw: boolean
+//   ): QueryResponse;
+//   executeTransaction(
+//     queries: { sql: string; params?: any[] }[],
+//     isRaw: boolean
+//   ): any[];
+// };
+
 export enum RegionLocationHint {
-    AUTO = 'auto',
-    WNAM = 'wnam', // Western North America
-    ENAM = 'enam', // Eastern North America
-    SAM = 'sam', // South America
-    WEUR = 'weur', // Western Europe
-    EEUR = 'eeur', // Eastern Europe
-    APAC = 'apac', // Asia Pacific
-    OC = 'oc', // Oceania
-    AFR = 'afr', // Africa
-    ME = 'me', // Middle East
+  AUTO = "auto",
+  WNAM = "wnam", // Western North America
+  ENAM = "enam", // Eastern North America
+  SAM = "sam", // South America
+  WEUR = "weur", // Western Europe
+  EEUR = "eeur", // Eastern Europe
+  APAC = "apac", // Asia Pacific
+  OC = "oc", // Oceania
+  AFR = "afr", // Africa
+  ME = "me", // Middle East
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,8 +8,8 @@ interface Env {
 	STUDIO_PASS: "123456";
 	ENABLE_ALLOWLIST: 0;
 	ENABLE_RLS: 0;
-	EXTERNAL_DB_TYPE: "postgres";
+	EXTERNAL_DB_TYPE: "postgresql";
 	AUTH_ALGORITHM: "RS256";
 	AUTH_JWKS_ENDPOINT: "";
-	DATABASE_DURABLE_OBJECT: DurableObjectNamespace<import("./src/index").DatabaseDurableObject>;
+	DATABASE_DURABLE_OBJECT: DurableObjectNamespace<import("./src/index").StarbaseDBDurableObject>;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -49,7 +49,7 @@ ENABLE_RLS = 0
 # External database source details
 # This enables Starbase to connect to an external data source
 # OUTERBASE_API_KEY = ""
-EXTERNAL_DB_TYPE = "postgres"
+EXTERNAL_DB_TYPE = "postgresql"
 # EXTERNAL_DB_HOST = ""
 # EXTERNAL_DB_PORT = 0
 # EXTERNAL_DB_USER = ""

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,13 +19,13 @@ enabled = true
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
 [[durable_objects.bindings]]
 name = "DATABASE_DURABLE_OBJECT"
-class_name = "DatabaseDurableObject"
+class_name = "StarbaseDBDurableObject"
 
 # Durable Object migrations.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["DatabaseDurableObject"]
+new_sqlite_classes = ["StarbaseDBDurableObject"]
 
 [vars]
 # Use this in your Authorization header for full database access


### PR DESCRIPTION
## Purpose

As discussed on Discord, this is a pretty large change to allow full configurability of Starbase and overhauls some of the internals.

Key changes:

- The internal DO is now passed around via `DataSource.rpc` as a single RPC Session, this means for the duration of a single request, we're only charged for a single DO request, whereas currently it's multiple.
- Internals now have no reference to the environment or request, this is now provided as configuration to the handler (now called `StarbaseDB`.
- The handler now accepts a features object (to be documented) where you can disable/enable certain features.
- The handler now accepts a reworked `DataSource` instance, with:
  - A `rpc` property. This is the result of calling the DO `init()` method to return an RPC session.
  - A `source`, either `external` or `internal`. For worker deployed users, this is still set via the `X-Starbase-Source` header.
  - A `cache` boolean property - works is set to `true` and source is `external`.  For worker deployed users, this is still set via the `X-Starbase-Cache` header is `true`.
  - A `context` property, which is what the RLS rules use. For worker deployed users, decodes the JWT and puts in the payload data. But for custom implementation, they can get the context from wherever they want.
  - An `external` property, which accepts a `ExternalDatabaseSource` type, which has all of our providers nicely typed.
- The `expireCache` logic has been moved into the internal handler.
- The handler now accepts a `role`, of either `admin` or `client`. Admin role does not apply allow list or RLS rules. For the deployed worker, this is set by observing the env api keys which are set.

Some additional notes / details:

- I have removed the MongoDB connection for now, since it doesn't support allow list or RLS due to the syntax differences. Let me know thoughts on this.
- I'm not sure if we can simply do this: `new_sqlite_classes = ["StarbaseDBDurableObject"]`? Do we have to tag the migration somehow?
- I noticed the current implementation checks the `source` on the URL when connecting via websocket... Shouldn't this be per query on the message level?

I've roughly tested things work.. but with no testing I'm conscious this is a big PR with lots of room to go wrong 👀 