### PR TITLE
Stripe Subscriptions Plugin

### DIFF
--- a/plugins/stripe/README.md
+++ b/plugins/stripe/README.md
@@ -26,6 +26,20 @@ const plugins = [
 
 ## How To Use
 
+### Webhook Setup
+
+For our Starbase instance to receive webhook events when subscription events change, we need to add our plugin endpoint to Stripe.
+
+1. Visit the Developer Webhooks page: https://dashboard.stripe.com/webhooks
+2. Click "+ Add Endpoint"
+3. Set "Endpoint URL" to `https://starbasedb.YOUR-IDENTIFIER.dev/stripe/webhook`
+4. Add two events to listen to:
+    - `customer.subscription.deleted`
+    - `checkout.session.completed`
+5. Save by clicking "Add Endpoint"
+
+### Product Subscription Setup
+
 After you create a subscription product inside of Stripe you can get the hosted link by following these steps:
 
 1. Click on the "Product catalog" section

--- a/plugins/stripe/README.md
+++ b/plugins/stripe/README.md
@@ -1,0 +1,52 @@
+# Stripe Subscriptions Plugin
+
+The Stripe Subscriptions Plugin for Starbase provides a quick and simple way for applications to begin accepting product subscription payments.
+
+## Usage
+
+Add the StripeSubscriptionPlugin plugin to your Starbase configuration:
+
+```typescript
+import { StripeSubscriptionPlugin } from './plugins/stripe'
+const plugins = [
+    // ... other plugins
+    new StripeSubscriptionPlugin({
+        stripeSecretKey: 'sk_test_**********',
+        stripeWebhookSecret: 'whsec_**********',
+    }),
+] satisfies StarbasePlugin[]
+```
+
+## Configuration Options
+
+| Option                | Type   | Default | Description                                                             |
+| --------------------- | ------ | ------- | ----------------------------------------------------------------------- |
+| `stripeSecretKey`     | string | `null`  | Access your secret key from (https://dashboard.stripe.com/apikeys)      |
+| `stripeWebhookSecret` | string | `null`  | Access your signing secret from (https://dashboard.stripe.com/webhooks) |
+
+## How To Use
+
+After you create a subscription product inside of Stripe you can get the hosted link by following these steps:
+
+1. Click on the "Product catalog" section
+2. Click on the product you want
+3. Click the "..." menu next to the Pricing item you want a link for
+4. Click "Create new payment link"
+
+Now you will have a new payment URL for you to direct your users to in order for them to checkout a new subscription of your product. We will take that URL and insert it
+into our frontend application similar to the example below.
+
+_IMPORTANT:_ You must append the `client_reference_id={userId}` at the end so we can attribute the correct user for the purchase.
+
+```html
+<body>
+    <a
+        href="https://buy.stripe.com/INSERT-SUBSCRIPTION-ID?client_reference_id=INSERT-USER-ID"
+        class="subscribe-button"
+    >
+        Subscribe
+    </a>
+</body>
+```
+
+Assuming all of the correct values were set in your installation phases, when a customer successfully subscribes via the Stripe Payment Link you should see a new entry automatically populate inside your SQLite table named `subscription`. At any point if this subscription is cancelled, even from the Stripe interface, the webhook will be handled via this plugin and automatically mark the `deleted_at` column with the date time it became inactive.

--- a/plugins/stripe/index.ts
+++ b/plugins/stripe/index.ts
@@ -1,0 +1,350 @@
+import { StarbaseApp, StarbaseContext } from '../../src/handler'
+import { StarbasePlugin } from '../../src/plugin'
+import { createResponse } from '../../src/utils'
+
+interface SubscriptionData {
+    userId: string
+    stripeCustomerId: string
+    stripeSubscriptionId: string
+}
+
+interface StripeAPIOptions {
+    method: string
+    path: string
+    body?: Record<string, any>
+}
+
+const SQL_QUERIES = {
+    CREATE_TABLE: `
+        CREATE TABLE IF NOT EXISTS subscription (
+            user_id TEXT PRIMARY KEY,
+            stripe_customer_id TEXT NOT NULL,
+            stripe_subscription_id TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            deleted_at DATETIME DEFAULT NULL
+        )
+    `,
+    UPSERT_SUBSCRIPTION: `
+        INSERT INTO subscription (user_id, stripe_customer_id, stripe_subscription_id)
+        VALUES (?, ?, ?)
+        ON CONFLICT(user_id) DO UPDATE SET
+        stripe_customer_id = excluded.stripe_customer_id,
+        stripe_subscription_id = excluded.stripe_subscription_id,
+        updated_at = CURRENT_TIMESTAMP,
+        deleted_at = NULL
+    `,
+    GET_ACTIVE_SUBSCRIPTION: `
+        SELECT stripe_subscription_id FROM subscription 
+        WHERE user_id = ? AND deleted_at IS NULL
+    `,
+    MARK_SUBSCRIPTION_DELETED: `
+        UPDATE subscription 
+        SET deleted_at = CURRENT_TIMESTAMP 
+        WHERE user_id = ? AND deleted_at IS NULL
+    `,
+    MARK_SUBSCRIPTION_DELETED_BY_ID: `
+        UPDATE subscription 
+        SET deleted_at = CURRENT_TIMESTAMP 
+        WHERE stripe_subscription_id = ? AND deleted_at IS NULL
+    `,
+}
+
+export class StripeSubscriptionPlugin extends StarbasePlugin {
+    context?: StarbaseContext
+    pathPrefix: string = '/stripe'
+    stripeSecretKey: string
+    stripeWebhookSecret: string
+
+    constructor(opts?: {
+        stripeSecretKey: string
+        stripeWebhookSecret: string
+    }) {
+        super('starbasedb:stripe-subscriptions', {
+            // The `requiresAuth` is set to false to allow for the webhooks to be accessible via Stripe
+            requiresAuth: false,
+        })
+        if (!opts?.stripeSecretKey) {
+            throw new Error('Stripe API key is required for this plugin.')
+        }
+        this.stripeSecretKey = opts.stripeSecretKey
+        this.stripeWebhookSecret = opts.stripeWebhookSecret
+    }
+
+    override async register(app: StarbaseApp) {
+        app.use(async (c, next) => {
+            this.context = c
+            const dataSource = c?.get('dataSource')
+
+            // Create subscription table if it doesn't exist
+            await dataSource?.rpc.executeQuery({
+                sql: SQL_QUERIES.CREATE_TABLE,
+                params: [],
+            })
+
+            await next()
+        })
+
+        // Route to subscribe a user to a product
+        app.post(`${this.pathPrefix}/subscribe`, async (c) => {
+            const {
+                userId,
+                stripeProductId: stripePriceId,
+                customerEmail,
+            } = await c.req.json()
+
+            if (!userId || !stripePriceId) {
+                return createResponse(
+                    undefined,
+                    'Missing required fields: userId, stripePriceId',
+                    400
+                )
+            }
+
+            try {
+                const customer: any = await this.createOrRetrieveCustomer(
+                    customerEmail || `${userId}@example.com`,
+                    userId
+                )
+
+                const subscription: any = await this.createSubscription(
+                    customer.id,
+                    stripePriceId
+                )
+
+                await this.updateSubscriptionData({
+                    userId,
+                    stripeCustomerId: customer.id,
+                    stripeSubscriptionId: subscription.id,
+                })
+
+                return createResponse(
+                    { success: true, subscriptionId: subscription.id },
+                    undefined,
+                    200
+                )
+            } catch (error: any) {
+                return createResponse(
+                    undefined,
+                    `Failed to subscribe: ${error.message}`,
+                    500
+                )
+            }
+        })
+
+        // Route to unsubscribe a user from a product
+        app.post(`${this.pathPrefix}/unsubscribe`, async (c) => {
+            const { userId } = await c.req.json()
+            const dataSource = this.context?.get('dataSource')
+
+            if (!userId) {
+                return new Response('Missing required fields: userId', {
+                    status: 400,
+                })
+            }
+
+            try {
+                // Retrieve subscription data from SQLite
+                const result: any = await dataSource?.rpc.executeQuery({
+                    sql: SQL_QUERIES.GET_ACTIVE_SUBSCRIPTION,
+                    params: [userId],
+                })
+
+                if (!result?.length) {
+                    return new Response('User not found', { status: 404 })
+                }
+
+                const stripeSubscriptionId = result[0].stripe_subscription_id
+
+                // Cancel the subscription
+                await this.cancelSubscription(stripeSubscriptionId)
+
+                // Remove from SQLite
+                await dataSource?.rpc.executeQuery({
+                    sql: SQL_QUERIES.MARK_SUBSCRIPTION_DELETED,
+                    params: [userId],
+                })
+
+                return createResponse({ success: true }, undefined, 200)
+            } catch (error: any) {
+                return createResponse(
+                    undefined,
+                    `Failed to subscribe: ${error.message}`,
+                    500
+                )
+            }
+        })
+
+        // Webhook to handle Stripe events
+        app.post(`${this.pathPrefix}/webhook`, async (c) => {
+            const body = await c.req.text()
+            const dataSource = this.context?.get('dataSource')
+
+            try {
+                const event = JSON.parse(body)
+
+                if (event.type === 'customer.subscription.deleted') {
+                    const subscription = event.data.object
+
+                    await dataSource?.rpc.executeQuery({
+                        sql: SQL_QUERIES.MARK_SUBSCRIPTION_DELETED_BY_ID,
+                        params: [subscription.id],
+                    })
+                } else if (event.type === 'checkout.session.completed') {
+                    const session = event.data.object
+
+                    if (session.subscription) {
+                        // Update subscription data in our database
+                        await this.updateSubscriptionData({
+                            userId: session.client_reference_id, // User needs to make sure to set this when creating checkout session (as a query param)
+                            stripeCustomerId: session.customer,
+                            stripeSubscriptionId: session.subscription,
+                        })
+                    }
+                }
+
+                return createResponse({ success: true }, undefined, 200)
+            } catch (error: any) {
+                console.error('Webhook processing error:', error)
+                return createResponse(
+                    undefined,
+                    `Webhook processing failed: ${error.message}`,
+                    400
+                )
+            }
+        })
+    }
+
+    private async callStripeAPI<T>({
+        method,
+        path,
+        body,
+    }: StripeAPIOptions): Promise<T> {
+        const url = `https://api.stripe.com/v1/${path}`
+        const headers: HeadersInit = {
+            Authorization: `Bearer ${this.stripeSecretKey}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        try {
+            const response = await fetch(url, {
+                method,
+                headers,
+                ...(body && { body: new URLSearchParams(body) }),
+            })
+
+            if (!response.ok) {
+                const errorData = await response.json()
+                throw new Error(
+                    `Stripe API call failed: ${response.statusText}. Details: ${JSON.stringify(errorData)}`
+                )
+            }
+
+            return response.json()
+        } catch (error: any) {
+            console.error('Stripe API error:', error)
+            throw error
+        }
+    }
+
+    private async updateSubscriptionData(data: SubscriptionData) {
+        const dataSource = this.context?.get('dataSource')
+        await dataSource?.rpc.executeQuery({
+            sql: SQL_QUERIES.UPSERT_SUBSCRIPTION,
+            params: [
+                data.userId,
+                data.stripeCustomerId,
+                data.stripeSubscriptionId,
+            ],
+        })
+    }
+
+    private async createOrRetrieveCustomer(email: string, userId: string) {
+        // First try to find by email as it's more reliable
+        const customersByEmail: any = await this.callStripeAPI({
+            method: 'GET',
+            path: `customers?email=${encodeURIComponent(email)}&limit=1`,
+        })
+
+        if (customersByEmail.data?.[0]) {
+            const customer = customersByEmail.data[0]
+
+            // Update the existing customer with our metadata
+            const updatedCustomer = await this.callStripeAPI({
+                method: 'POST',
+                path: `customers/${customer.id}`,
+                body: {
+                    'metadata[user_id]': userId,
+                },
+            })
+
+            return updatedCustomer
+        }
+
+        // If no customer exists, create a new one
+        return this.callStripeAPI({
+            method: 'POST',
+            path: 'customers',
+            body: {
+                email,
+                'metadata[user_id]': userId,
+            },
+        })
+    }
+
+    private async createSubscription(
+        customerId: string,
+        priceOrProductId: string
+    ) {
+        // If a product ID is provided, we need to look up its price first
+        let priceId = priceOrProductId
+
+        if (priceOrProductId.startsWith('prod_')) {
+            // Fetch the first active price for this product
+            const prices: any = await this.callStripeAPI({
+                method: 'GET',
+                path: `prices?product=${priceOrProductId}&active=true&limit=1`,
+            })
+
+            if (!prices.data?.[0]?.id) {
+                throw new Error('No active price found for this product')
+            }
+
+            priceId = prices.data[0].id
+        }
+
+        // Get customer's default payment method
+        const customer: any = await this.callStripeAPI({
+            method: 'GET',
+            path: `customers/${customerId}`,
+        })
+
+        if (
+            !customer.default_payment_method &&
+            !customer.invoice_settings?.default_payment_method
+        ) {
+            throw new Error(
+                'Customer has no default payment method. Please add a payment method first.'
+            )
+        }
+
+        return this.callStripeAPI({
+            method: 'POST',
+            path: 'subscriptions',
+            body: {
+                customer: customerId,
+                'items[0][price]': priceId,
+                default_payment_method:
+                    customer.default_payment_method ||
+                    customer.invoice_settings.default_payment_method,
+            },
+        })
+    }
+
+    private async cancelSubscription(subscriptionId: string) {
+        return this.callStripeAPI({
+            method: 'DELETE',
+            path: `subscriptions/${subscriptionId}`,
+        })
+    }
+}

--- a/plugins/stripe/meta.json
+++ b/plugins/stripe/meta.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.0",
     "resources": {
         "tables": {
             "subscription": [
@@ -15,7 +16,7 @@
     },
     "dependencies": {
         "tables": {
-            "user": ["id", "email"]
+            "*": ["user_id"]
         },
         "secrets": {},
         "variables": {}

--- a/plugins/stripe/meta.json
+++ b/plugins/stripe/meta.json
@@ -1,0 +1,23 @@
+{
+    "resources": {
+        "tables": {
+            "subscription": [
+                "user_id",
+                "stripe_customer_id",
+                "stripe_subscription_id",
+                "created_at",
+                "updatd_at",
+                "deleted_at"
+            ]
+        },
+        "secrets": {},
+        "variables": {}
+    },
+    "dependencies": {
+        "tables": {
+            "user": ["id", "email"]
+        },
+        "secrets": {},
+        "variables": {}
+    }
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -205,7 +205,7 @@ export class StarbaseDB {
                     .replace(/:[^/]+/g, '[^/]+') // Replace :param with regex pattern
                     .replace(/\*/g, '.*') // Replace * with wildcard pattern
 
-                const regex = new RegExp(`^${pathPattern}$`)
+                const regex = new RegExp(`^${pathPattern}`)
                 return regex.test(urlPath)
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,6 @@ export default {
                     password: env.STUDIO_PASS,
                     apiKey: env.ADMIN_AUTHORIZATION_TOKEN,
                 }),
-                new StripeSubscriptionPlugin({
-                    stripeSecretKey: '',
-                    stripeWebhookSecret: '',
-                }),
             ] satisfies StarbasePlugin[]
 
             const starbase = new StarbaseDB({

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { corsPreflight } from './cors'
 import { StarbasePlugin } from './plugin'
 import { WebSocketPlugin } from '../plugins/websocket'
 import { StudioPlugin } from '../plugins/studio'
+import { StripeSubscriptionPlugin } from '../plugins/stripe'
 
 export { StarbaseDBDurableObject } from './do'
 
@@ -174,6 +175,10 @@ export default {
                     username: env.STUDIO_USER,
                     password: env.STUDIO_PASS,
                     apiKey: env.ADMIN_AUTHORIZATION_TOKEN,
+                }),
+                new StripeSubscriptionPlugin({
+                    stripeSecretKey: '',
+                    stripeWebhookSecret: '',
                 }),
             ] satisfies StarbasePlugin[]
 


### PR DESCRIPTION
## Purpose
Easily supporting Stripe Subscriptions in your user facing applications shouldn't feel like a headache waiting to happen or a nightmare you're putting off. As part of the Starbase plugin ecosystem we want to tackle some of the hardest developer challenges with simple lines of required code so developers can focus on what makes their applications... theirs.

This pull request introduces the ability to provide two values from Stripe for your database to start tracking subscriptions. When the plugin is registered it will automatically create a SQL table on your behalf with the correct schema. When a user checks out a product via a Stripe Product Link the entries will be stored in your database automatically. And when a product/subscription is cancelled a webhook will be triggered that marks it with a soft delete by populating the `deleted_at` column in the database table.

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] Automatically create a database table to handle subscription logic
- [X] Allow users to add a Stripe plugin to subscribe and unsubscribe
- [X] Have a webhook endpoint Stripe can trigger on server event changes

## Verify

<!-- guidance or steps to assist the reviewer -->

Include the plugin in `./src/index.ts`
```typescript
import { StripeSubscriptionPlugin } from './plugins/stripe'
const plugins = [
    // ... other plugins
    new StripeSubscriptionPlugin({
        stripeSecretKey: 'sk_test_**********',
        stripeWebhookSecret: 'whsec_**********',
    }),
] satisfies StarbasePlugin[]
```

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
https://github.com/user-attachments/assets/762dab8f-5ce4-4e69-8cda-74a42a6cdf60

