### PR TITLE
Prefer web socket method DO vs Worker for sources

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,9 @@ export default {
             }
 
             const plugins = [
-                new WebSocketPlugin(),
+                new WebSocketPlugin({
+                    stub,
+                }),
                 new StudioPlugin({
                     username: env.STUDIO_USER,
                     password: env.STUDIO_PASS,

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -23,7 +23,6 @@ import { afterQueryCache, beforeQueryCache } from './cache'
 import { isQueryAllowed } from './allowlist'
 import { applyRLS } from './rls'
 import type { SqlConnection } from '@outerbase/sdk/dist/connections/sql-base'
-import { StarbasePlugin } from './plugin'
 
 export type OperationQueueItem = {
     queries: { sql: string; params?: any[] }[]


### PR DESCRIPTION
## Purpose
Originally all web socket communication was handled via the Durable Object and its hibernation API. Then with the introduction of external data sources we abstracted the web socket communication to live more ephemerally on the Worker and we removed the socket handler on DO's. Now... we're bringing it back!

**Why?**
Web socket connections on the durable object can handle state between requests. Allowing web sockets to be handled at this level will provide additional flexibility for developers interfacing via Starbase plugins to achieve their goals.

**Should all web sockets move to Durable Objects?**
TLDR; I don't believe so.
For externally connected databases we use web sockets via the Worker instead of the Durable Object. Could a case be made that handling state between multiple web socket messages makes sense for these data sources? Sure. But at the moment we would need to then also migrate all of our code of how we communicate with those data sources to being inside a DO and that comes with downside. The upside of communicating with an external data source via a Worker is the worker is on the edge and acts as a node en route to the destination. If we were to move it to a Durable Object, there are far fewer global nodes, less possibilities with throughput (RPS), and overall would likely slow down those responses overall.

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] Internal source `/socket` requests use Durable Objects web sockets
- [X] External source `/socket` requests use Workers web sockets
- [X] FIX: Issue where running `executeTransaction` in a DO was not returning results

## Verify

<!-- guidance or steps to assist the reviewer -->

-

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
