### PR TITLE
feat: Omit queries from QueryLog plugin

### DIFF
--- a/plugins/query-log/index.ts
+++ b/plugins/query-log/index.ts
@@ -20,6 +20,10 @@ export class QueryLogPlugin extends StarbasePlugin {
     executionContext?: ExecutionContext
     // Add TTL configuration (default 1 day)
     private readonly ttl: number = 1
+    // Enables the omission of queries who contain the prefix
+    omitEnabled?: boolean = false
+    // Prefix that if a query contains it won't be logged
+    omitPrefix: string = '--OMIT'
 
     state = {
         startTime: new Date(),
@@ -28,9 +32,18 @@ export class QueryLogPlugin extends StarbasePlugin {
         query: '',
     }
 
-    constructor(opts?: { ctx?: ExecutionContext }) {
+    constructor(opts?: {
+        ctx?: ExecutionContext
+        enableOmit?: boolean
+        omitPrefix?: string
+    }) {
         super('starbasedb:query-log')
         this.executionContext = opts?.ctx
+        this.omitEnabled = opts?.enableOmit
+
+        if (opts?.omitPrefix) {
+            this.omitPrefix = opts?.omitPrefix
+        }
     }
 
     override async register(app: StarbaseApp) {
@@ -74,7 +87,12 @@ export class QueryLogPlugin extends StarbasePlugin {
         this.state.totalTime =
             this.state.endTime.getTime() - this.state.startTime.getTime()
 
-        if (opts.dataSource) {
+        // Queries can be omitted from
+        if (
+            opts.dataSource &&
+            !opts.sql.toUpperCase().trim().startsWith(this.omitPrefix) &&
+            this.omitEnabled
+        ) {
             this.addQuery(opts?.dataSource)
         }
 


### PR DESCRIPTION
## Purpose
When using the `QueryLogPlugin` allow users to opt-into allowing some queries that contain a specific prefix to be omitted from the log. Use cases might include administrative queries that happen frequently and would add noise to a more user-focused query log.

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [ ] Allow users to opt-in to the `omit` functionality
- [ ] Allow users to override the default `--OMIT` prefix

## Verify

<!-- guidance or steps to assist the reviewer -->

-

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
