### PR TITLE
feat: Statistics and information about instance

### DIFF
--- a/plugins/stats/index.ts
+++ b/plugins/stats/index.ts
@@ -1,0 +1,45 @@
+import { DataSource } from '../../dist'
+import { StarbaseApp, StarbaseDBConfiguration } from '../../src/handler'
+import { StarbasePlugin } from '../../src/plugin'
+
+export class StatsPlugin extends StarbasePlugin {
+    // Prefix route
+    prefix: string = '/_internal/stats'
+    // Configuration details about the request and user
+    private config?: StarbaseDBConfiguration
+    // Data source to run internal RPC queries
+    dataSource?: DataSource
+
+    constructor() {
+        super('starbasedb:stats', {
+            requiresAuth: true,
+        })
+    }
+
+    override async register(app: StarbaseApp) {
+        app.use(async (c, next) => {
+            this.config = c?.get('config')
+            this.dataSource = c?.get('dataSource')
+            await next()
+        })
+
+        app.get(this.prefix, async (c, next) => {
+            // Only admin authorized users are permitted to subscribe to CDC events.
+            if (this.config?.role !== 'admin') {
+                return new Response('Unauthorized request', { status: 400 })
+            }
+
+            // Get stats from internal source
+            const stats = await this.dataSource?.rpc.getStatistics()
+            const additionalStats = {
+                ...stats,
+                plugins: this.dataSource?.registry?.currentPlugins(),
+            }
+            return new Response(JSON.stringify(additionalStats), {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            })
+        })
+    }
+}

--- a/src/do.ts
+++ b/src/do.ts
@@ -73,7 +73,9 @@ export class StarbaseDBDurableObject extends DurableObject {
         activeConnections: number
         recentQueries: number
     }> {
-        const sql = 'SELECT COUNT(*) as count FROM tmp_query_log'
+        const sql = `SELECT COUNT(*) as count 
+            FROM tmp_query_log 
+            WHERE created_at >= datetime('now', '-24 hours')`
         const result = (await this.executeQuery({
             sql,
             isRaw: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { StudioPlugin } from '../plugins/studio'
 import { SqlMacrosPlugin } from '../plugins/sql-macros'
 import { ChangeDataCapturePlugin } from '../plugins/cdc'
 import { QueryLogPlugin } from '../plugins/query-log'
+import { StatsPlugin } from '../plugins/stats'
 
 export { StarbaseDBDurableObject } from './do'
 
@@ -190,6 +191,7 @@ export default {
                 }),
                 new QueryLogPlugin({ ctx }),
                 cdcPlugin,
+                new StatsPlugin(),
             ] satisfies StarbasePlugin[]
 
             const starbase = new StarbaseDB({

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -70,6 +70,10 @@ export class StarbasePluginRegistry {
         }
     }
 
+    public currentPlugins(): string[] {
+        return this.plugins.map((plugin) => plugin.name)
+    }
+
     public async beforeQuery(opts: {
         sql: string
         params?: unknown[]

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,7 +8,6 @@ interface Env {
     STUDIO_PASS: '123456'
     ENABLE_ALLOWLIST: 0
     ENABLE_RLS: 0
-    EXTERNAL_DB_TYPE: 'postgresql'
     AUTH_ALGORITHM: 'RS256'
     AUTH_JWKS_ENDPOINT: ''
     DATABASE_DURABLE_OBJECT: DurableObjectNamespace<

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -49,7 +49,7 @@ ENABLE_RLS = 0
 # External database source details
 # This enables Starbase to connect to an external data source
 # OUTERBASE_API_KEY = ""
-EXTERNAL_DB_TYPE = "postgresql"
+# EXTERNAL_DB_TYPE = "postgresql"
 # EXTERNAL_DB_HOST = ""
 # EXTERNAL_DB_PORT = 0
 # EXTERNAL_DB_USER = ""


### PR DESCRIPTION
## Purpose
The intent behind this pull request is to expose information about the deployed instance and expose it via a new route `/_internal/stats` when the `ADMIN_AUTHORIZATION_TOKEN` is passed in as the Authorization header. Primary driver for this is more of an internal business use case to populate a dashboard with metadata information for users to have quick insights to what is currently happening (reference image below).

![image](https://github.com/user-attachments/assets/5fdc4e8f-9890-41f6-9cbe-7aef2d0988a9)

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] Show database size (in bytes)
- [X] Show recent queries count (dependent on `QueryLogPlugin`)
- [X] Show active persistent WebSocket connections in DO
- [X] Show names of installed plugins

## Verify
```
curl --location --request GET 'https://starbasedb.{YOUR-IDENTIFIER}.dev/_internal/stats' \
--header 'Authorization: Bearer ABC123' \
```

## Before
N/A

## After
```
{
    "databaseSize": 65536,
    "activeConnections": 0,
    "recentQueries": 4,
    "plugins": [
        "starbasedb:websocket",
        "starbasedb:studio",
        "starbasedb:sql-macros",
        "starbasedb:query-log",
        "starbasedb:change-data-capture",
        "starbasedb:stats"
    ]
}
```
