### PR TITLE
bug: Return with CORS headers

### DIFF
--- a/plugins/stats/index.ts
+++ b/plugins/stats/index.ts
@@ -1,6 +1,7 @@
 import { DataSource } from '../../dist'
 import { StarbaseApp, StarbaseDBConfiguration } from '../../src/handler'
 import { StarbasePlugin } from '../../src/plugin'
+import { createResponse } from '../../src/utils'
 
 export class StatsPlugin extends StarbasePlugin {
     // Prefix route
@@ -35,11 +36,7 @@ export class StatsPlugin extends StarbasePlugin {
                 ...stats,
                 plugins: this.dataSource?.registry?.currentPlugins(),
             }
-            return new Response(JSON.stringify(additionalStats), {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-            })
+            return createResponse(additionalStats, undefined, 200)
         })
     }
 }


### PR DESCRIPTION
## Purpose
Previous PR was returning the `/_internal/stats` endpoint without the proper CORS headers attached to the response.

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] Return results with prebuilt `createResponse` function

## Verify

<!-- guidance or steps to assist the reviewer -->

-

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
