### PR TITLE
bug: Return connections map size

### DIFF
--- a/src/do.ts
+++ b/src/do.ts
@@ -86,7 +86,7 @@ export class StarbaseDBDurableObject extends DurableObject {
             // Size in bytes
             databaseSize: this.sql.databaseSize,
             // Count of persistent web socket connections
-            activeConnections: this.connections.keys.length,
+            activeConnections: this.connections.size,
             // Assuming the `QueryLogPlugin` is in use, count is of the last 24 hours
             recentQueries: Number(row.count),
         }


### PR DESCRIPTION
## Purpose
Fix an issue where returning the Map size was incorrectly using `.keys.length` instead of `.size`

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] Return map length with `.size` property

## Verify

<!-- guidance or steps to assist the reviewer -->

-

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
