### PR TITLE
Simultaneous Cron Alarms

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dependencies": {
         "@libsql/client": "^0.14.0",
         "@outerbase/sdk": "2.0.0-rc.3",
+        "cron-parser": "^4.9.0",
         "hono": "^4.6.14",
         "jose": "^5.9.6",
         "mongodb": "^6.11.0",

--- a/plugins/cron/README.md
+++ b/plugins/cron/README.md
@@ -1,0 +1,35 @@
+## Example Usage
+
+Each task should have an entry in the `tmp_cron_tasks` table of your StarbaseDB instance. An example row might look like:
+
+```json
+{
+    "name": "Even minutes",
+    "cron_tab": "*/2 * * * *",
+    "payload": "",
+    "callback_host": "https://starbasedb-{MY-IDENTIFIER}.workers.dev"
+}
+```
+
+Then your code in your `/src/index.ts` would implement the plugin setup like below:
+
+```ts
+import { CronPlugin } from '../plugins/cron'
+
+// ....
+// ....
+
+const cronPlugin = new CronPlugin()
+cronPlugin.onEvent(({ name, cron_tab, payload }) => {
+    console.log('CRON EVENT: ', name, cron_tab, payload)
+
+    if (name === 'Even minutes') {
+        console.log('Payload: ', JSON.stringify(payload))
+    }
+}, ctx)
+
+const plugins = [
+    // ...
+    cronPlugin,
+] satisfies StarbasePlugin[]
+```

--- a/plugins/cron/index.ts
+++ b/plugins/cron/index.ts
@@ -1,0 +1,210 @@
+import { StarbaseApp } from '../../src/handler'
+import { StarbasePlugin } from '../../src/plugin'
+import { DataSource, QueryResult } from '../../src/types'
+import { createResponse } from '../../src/utils'
+import { getNextExecutionTime } from './utils'
+
+const SQL_QUERIES = {
+    CREATE_TABLE: `
+        CREATE TABLE IF NOT EXISTS tmp_cron_tasks (
+            name TEXT PRIMARY KEY,
+            cron_tab TEXT NOT NULL,
+            payload TEXT,
+            callback_host TEXT,
+            is_active INTEGER
+        )
+    `,
+    INSERT_TASK: `
+        INSERT OR REPLACE INTO tmp_cron_tasks (name, cron_tab, payload, callback_host)
+        VALUES (?, ?, ?, ?)
+    `,
+    GET_TASKS: `
+        SELECT name, cron_tab, payload 
+        FROM tmp_cron_tasks
+    `,
+    DELETE_TASK: `
+        DELETE FROM tmp_cron_tasks WHERE name = ?
+    `,
+    // The below query allows up to 10 cron events set to `is_active`. At the moment
+    // it is hard coded constrained but adding more WHEN clause rows will up that limit.
+    UPDATE_ACTIVE_STATUS: `
+        UPDATE tmp_cron_tasks 
+        SET is_active = CASE 
+            WHEN name = ? THEN 1 
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            WHEN name = ? THEN 1
+            ELSE 0 
+        END
+    `,
+}
+
+export interface CronEventPayload {
+    name: string
+    cron_tab: string
+    payload: Record<string, any>
+}
+
+export class CronPlugin extends StarbasePlugin {
+    public prefix: string = '/cron'
+    private dataSource?: DataSource
+    private eventCallbacks: ((payload: CronEventPayload) => void)[] = []
+
+    constructor() {
+        super('starbasedb:cron', {
+            requiresAuth: true,
+        })
+    }
+
+    override async register(app: StarbaseApp) {
+        app.use(async (c, next) => {
+            this.dataSource = c?.get('dataSource')
+            await this.init()
+            await this.scheduleNextAlarm()
+            await next()
+        })
+
+        app.post(`${this.prefix}/callback`, async (c) => {
+            const payload = (await c.req.json()) as CronEventPayload[]
+
+            this.eventCallbacks.forEach((callback) => {
+                try {
+                    payload.forEach((element) => {
+                        callback(element)
+                    })
+                } catch (error) {
+                    console.error('Error in Cron event callback:', error)
+                }
+            })
+
+            return createResponse({ success: true }, undefined, 200)
+        })
+    }
+
+    private async init() {
+        if (!this.dataSource) return
+
+        // Create cron tasks table if it doesn't exist
+        await this.dataSource.rpc.executeQuery({
+            sql: SQL_QUERIES.CREATE_TABLE,
+            params: [],
+        })
+    }
+
+    private async scheduleNextAlarm() {
+        if (!this.dataSource) return
+
+        // Get all tasks from our database table
+        const result = (await this.dataSource.rpc.executeQuery({
+            sql: SQL_QUERIES.GET_TASKS,
+            params: [],
+        })) as QueryResult[]
+
+        const tasks = result as {
+            name: string
+            cron_tab: string
+            payload: string
+        }[]
+
+        /**
+         * No tasks exist. There are two options here we can proceed with:
+         * 1. Delete the existing alarm in case they removed the task and no longer needed
+         * 2. Leave any alarms and just return early (in case other plugins utilize Alarms)
+         *
+         * For the purpose of this plugin in its current state we are going to simply
+         * return early so if other plugins utilize the Alarm we're not disrupting the
+         * service(s) they provide. A side effect to this decision is that if you delete
+         * a cron task from this plugin you may get one last lingering message sent that
+         * is currently set to be triggered.
+         */
+        if (tasks.length === 0) {
+            // await this.dataSource.rpc.deleteAlarm() <-- We are intentionally _NOT_ calling this.
+            return
+        }
+
+        // Find the next execution time for each task
+        const now = Date.now()
+        let nextExecutionMs = Infinity
+        let nextTasks: typeof tasks = []
+
+        for (const task of tasks) {
+            const nextTime = getNextExecutionTime(task.cron_tab, now)
+
+            if (nextTime < nextExecutionMs && nextTime > now) {
+                nextExecutionMs = nextTime
+                nextTasks = [task]
+            } else if (nextTime === nextExecutionMs && nextTime > now) {
+                nextTasks.push(task)
+            }
+        }
+
+        if (nextTasks.length > 0) {
+            console.log(
+                'Cron Task(s) Queued:',
+                nextTasks.map((t) => t.name).join(', '),
+                'at',
+                new Date(nextExecutionMs).toISOString()
+            )
+
+            // Update active status for all tasks
+            // Fill remaining parameter slots with null if fewer than 10 tasks
+            const taskNames = [
+                ...nextTasks.map((t) => t.name),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+            ].slice(0, 10)
+            await this.dataSource.rpc.executeQuery({
+                sql: SQL_QUERIES.UPDATE_ACTIVE_STATUS,
+                params: taskNames,
+            })
+
+            await this.dataSource.rpc.setAlarm(nextExecutionMs)
+        }
+    }
+
+    public async addEvent(
+        cronTab: string,
+        name: string,
+        payload: Record<string, any> = {},
+        callbackHost: string
+    ) {
+        if (!this.dataSource)
+            throw new Error('CronPlugin not properly initialized')
+
+        await this.dataSource.rpc.executeQuery({
+            sql: SQL_QUERIES.INSERT_TASK,
+            params: [name, cronTab, JSON.stringify(payload), callbackHost],
+        })
+
+        // Reschedule alarms after adding new task
+        await this.scheduleNextAlarm()
+    }
+
+    public onEvent(
+        callback: (payload: CronEventPayload) => void | Promise<void>,
+        ctx?: ExecutionContext
+    ) {
+        const wrappedCallback = async (payload: CronEventPayload) => {
+            const result = callback(payload)
+            if (result instanceof Promise && ctx) {
+                ctx.waitUntil(result)
+            }
+        }
+
+        this.eventCallbacks.push(wrappedCallback)
+    }
+}

--- a/plugins/cron/index.ts
+++ b/plugins/cron/index.ts
@@ -7,7 +7,7 @@ import { getNextExecutionTime } from './utils'
 const SQL_QUERIES = {
     CREATE_TABLE: `
         CREATE TABLE IF NOT EXISTS tmp_cron_tasks (
-            name TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE PRIMARY KEY,
             cron_tab TEXT NOT NULL,
             payload TEXT,
             callback_host TEXT,
@@ -52,7 +52,7 @@ export interface CronEventPayload {
 }
 
 export class CronPlugin extends StarbasePlugin {
-    public prefix: string = '/cron'
+    public pathPrefix: string = '/cron'
     private dataSource?: DataSource
     private eventCallbacks: ((payload: CronEventPayload) => void)[] = []
 
@@ -70,7 +70,7 @@ export class CronPlugin extends StarbasePlugin {
             await next()
         })
 
-        app.post(`${this.prefix}/callback`, async (c) => {
+        app.post(`${this.pathPrefix}/callback`, async (c) => {
             const payload = (await c.req.json()) as CronEventPayload[]
 
             this.eventCallbacks.forEach((callback) => {
@@ -145,13 +145,6 @@ export class CronPlugin extends StarbasePlugin {
         }
 
         if (nextTasks.length > 0) {
-            console.log(
-                'Cron Task(s) Queued:',
-                nextTasks.map((t) => t.name).join(', '),
-                'at',
-                new Date(nextExecutionMs).toISOString()
-            )
-
             // Update active status for all tasks
             // Fill remaining parameter slots with null if fewer than 10 tasks
             const taskNames = [

--- a/plugins/cron/utils.ts
+++ b/plugins/cron/utils.ts
@@ -1,0 +1,13 @@
+import * as cronParser from 'cron-parser'
+
+export function parseCronExpression(cronTab: string) {
+    return cronParser.parseExpression(cronTab)
+}
+
+export function getNextExecutionTime(cronTab: string, after: number): number {
+    const interval = cronParser.parseExpression(cronTab, {
+        currentDate: new Date(after),
+    })
+    const next = interval.next()
+    return next.getTime()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@outerbase/sdk':
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
+      cron-parser:
+        specifier: ^4.9.0
+        version: 4.9.0
       hono:
         specifier: ^4.6.14
         version: 4.6.14
@@ -820,6 +823,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1120,6 +1127,10 @@ packages:
   lru.min@1.1.1:
     resolution: {integrity: sha512-FbAj6lXil6t8z4z3j0E5mfRlPzxkySotzUHwRXjlpRh10vc6AI6WN62ehZj82VG7M20rqogJ0GLwar2Xa05a8Q==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  luxon@3.5.0:
+    resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
+    engines: {node: '>=12'}
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -2370,6 +2381,10 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.5.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2694,6 +2709,8 @@ snapshots:
   lru-cache@7.18.3: {}
 
   lru.min@1.1.1: {}
+
+  luxon@3.5.0: {}
 
   magic-string@0.25.9:
     dependencies:

--- a/src/do.ts
+++ b/src/do.ts
@@ -3,9 +3,12 @@ import { DurableObject } from 'cloudflare:workers'
 export class StarbaseDBDurableObject extends DurableObject {
     // Durable storage for the SQL database
     public sql: SqlStorage
+    // Durable storage for the instance
     public storage: DurableObjectStorage
     // Map of WebSocket connections to their corresponding session IDs
     public connections = new Map<string, WebSocket>()
+    // Store the client auth token for requests back to our Worker
+    private clientAuthToken: string
 
     /**
      * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
@@ -16,6 +19,7 @@ export class StarbaseDBDurableObject extends DurableObject {
      */
     constructor(ctx: DurableObjectState, env: Env) {
         super(ctx, env)
+        this.clientAuthToken = env.CLIENT_AUTHORIZATION_TOKEN
         this.sql = ctx.storage.sql
         this.storage = ctx.storage
 
@@ -63,8 +67,84 @@ export class StarbaseDBDurableObject extends DurableObject {
 
     init() {
         return {
+            getAlarm: this.getAlarm.bind(this),
+            setAlarm: this.setAlarm.bind(this),
+            deleteAlarm: this.deleteAlarm.bind(this),
             getStatistics: this.getStatistics.bind(this),
             executeQuery: this.executeQuery.bind(this),
+        }
+    }
+
+    public async getAlarm(): Promise<number | null> {
+        return await this.storage.getAlarm()
+    }
+
+    public async setAlarm(
+        scheduledTime: number | Date,
+        options?: DurableObjectSetAlarmOptions
+    ): Promise<void> {
+        try {
+            const now = Date.now()
+            const inputTime =
+                scheduledTime instanceof Date
+                    ? scheduledTime.getTime()
+                    : scheduledTime
+
+            // Ensure the time is in the future and at least 1 second from now
+            const minimumTime = now + 1000
+            const finalTime = Math.max(inputTime, minimumTime)
+            await this.storage.setAlarm(finalTime, options)
+        } catch (e) {
+            console.error('Error setting alarm: ', e)
+            throw e
+        }
+    }
+
+    public deleteAlarm(options?: DurableObjectSetAlarmOptions): Promise<void> {
+        return this.storage.deleteAlarm(options)
+    }
+
+    async alarm() {
+        try {
+            // Fetch all the tasks that are marked to emit an event for this cycle.
+            const task = (await this.executeQuery({
+                sql: 'SELECT * FROM tmp_cron_tasks WHERE is_active = 1;',
+                isRaw: false,
+            })) as Record<string, SqlStorageValue>[]
+
+            if (!task.length) {
+                return
+            }
+
+            try {
+                const firstTask = task[0]
+                await fetch(`${firstTask.callback_host}/cron/callback`, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${this.clientAuthToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(task ?? []),
+                })
+            } catch (error) {
+                console.error('Failed to call the alarm/cron callback:', error)
+
+                // If the callback fails, we should try to reschedule to prevent the chain from breaking
+                try {
+                    await this.setAlarm(Date.now() + 60000)
+                } catch (retryError) {
+                    console.error('Failed to set recovery alarm:', retryError)
+                }
+            }
+        } catch (e) {
+            console.error('There was an error processing an alarm: ', e)
+
+            // Try to recover by scheduling a retry in 1 minute
+            try {
+                await this.setAlarm(Date.now() + 60000)
+            } catch (retryError) {
+                console.error('Failed to set recovery alarm:', retryError)
+            }
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { SqlMacrosPlugin } from '../plugins/sql-macros'
 import { ChangeDataCapturePlugin } from '../plugins/cdc'
 import { QueryLogPlugin } from '../plugins/query-log'
 import { StatsPlugin } from '../plugins/stats'
+import { CronPlugin } from '../plugins/cron'
 
 export { StarbaseDBDurableObject } from './do'
 
@@ -173,11 +174,16 @@ export default {
             }
 
             const webSocketPlugin = new WebSocketPlugin()
+            const cronPlugin = new CronPlugin()
             const cdcPlugin = new ChangeDataCapturePlugin({
                 stub,
                 broadcastAllEvents: false,
                 events: [],
             })
+
+            cdcPlugin.onEvent(({ action, schema, table, data }) => {}, ctx)
+
+            cronPlugin.onEvent(({ name, cron_tab, payload }) => {}, ctx)
 
             const plugins = [
                 webSocketPlugin,
@@ -191,6 +197,7 @@ export default {
                 }),
                 new QueryLogPlugin({ ctx }),
                 cdcPlugin,
+                cronPlugin,
                 new StatsPlugin(),
             ] satisfies StarbasePlugin[]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,9 +181,13 @@ export default {
                 events: [],
             })
 
-            cdcPlugin.onEvent(({ action, schema, table, data }) => {}, ctx)
+            cdcPlugin.onEvent(({ action, schema, table, data }) => {
+                // Include change data capture code here
+            }, ctx)
 
-            cronPlugin.onEvent(({ name, cron_tab, payload }) => {}, ctx)
+            cronPlugin.onEvent(({ name, cron_tab, payload }) => {
+                // Include cron event code here
+            }, ctx)
 
             const plugins = [
                 webSocketPlugin,


### PR DESCRIPTION
## Purpose
This enables StarbaseDB instances to be able to declare hooks in the `/src/index.ts` file to execute custom code at defined crontab intervals. By default Durable Objects can support 1 Alarm at a time (and Workers can support 3 cron jobs) but we need the ability to expand it so any number of events can signup to execute code at any interval. See below example for implementation.

Currently there is a hardcoded limit of supporting 10 simultaneous events to trigger at any given interval which can easily be updated by adding more WHEN cases to the query. This was a technical decision for the moment to prevent accidental setups of recursively added calls but can easily be updated to support `N` events at any time.

## Tasks

<!-- [ ] incomplete; [x] complete -->

- [X] When a request comes in, ensure an alarm is set if a task is defined in `tmp_cron_tasks` table
- [X] If multiple tasks should happen at the same time, both should emit an event individually
- [X] Setup retries for failed alarms

## Verify

Each task should have an entry in the `tmp_cron_tasks` table of your StarbaseDB instance. An example row might look like:

```json
{
    "name": "Even minutes",
    "cron_tab": "*/2 * * * *",
    "payload": "",
    "callback_host": "https://starbasedb-{MY-IDENTIFIER}.workers.dev"
}
```

Then your code in your `/src/index.ts` would implement the plugin setup like below:

```ts
import { CronPlugin } from '../plugins/cron'

// ....
// ....

const cronPlugin = new CronPlugin()
cronPlugin.onEvent(({ name, cron_tab, payload }) => {
    console.log('CRON EVENT: ', name, cron_tab, payload)

    if (name === 'Even minutes') {
        console.log('Payload: ', JSON.stringify(payload))
    }
}, ctx)

const plugins = [
    // ...
    cronPlugin,
] satisfies StarbasePlugin[]
```

## Before

<!-- screenshot before changes -->

## After

<!-- screenshot after changes -->
