### PR TITLE
fix: Database dumps do not work on large databases

### DIFF
--- a/src/export/dump.test.ts
+++ b/src/export/dump.test.ts
@@ -42,16 +42,24 @@ describe('Database Dump Module', () => {
     it('should return a database dump when tables exist', async () => {
         vi.mocked(executeOperation)
             .mockResolvedValueOnce([{ name: 'users' }, { name: 'orders' }])
+            // users schema
             .mockResolvedValueOnce([
                 { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
             ])
+            // users count
+            .mockResolvedValueOnce([{ count: 2 }])
+            // users data batch
             .mockResolvedValueOnce([
                 { id: 1, name: 'Alice' },
                 { id: 2, name: 'Bob' },
             ])
+            // orders schema
             .mockResolvedValueOnce([
                 { sql: 'CREATE TABLE orders (id INTEGER, total REAL);' },
             ])
+            // orders count
+            .mockResolvedValueOnce([{ count: 2 }])
+            // orders data batch
             .mockResolvedValueOnce([
                 { id: 1, total: 99.99 },
                 { id: 2, total: 49.5 },
@@ -99,7 +107,8 @@ describe('Database Dump Module', () => {
             .mockResolvedValueOnce([
                 { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
             ])
-            .mockResolvedValueOnce([])
+            // count returns 0
+            .mockResolvedValueOnce([{ count: 0 }])
 
         const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
 
@@ -117,6 +126,7 @@ describe('Database Dump Module', () => {
             .mockResolvedValueOnce([
                 { sql: 'CREATE TABLE users (id INTEGER, bio TEXT);' },
             ])
+            .mockResolvedValueOnce([{ count: 1 }])
             .mockResolvedValueOnce([{ id: 1, bio: "Alice's adventure" }])
 
         const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
@@ -141,5 +151,61 @@ describe('Database Dump Module', () => {
         expect(response.status).toBe(500)
         const jsonResponse: { error: string } = await response.json()
         expect(jsonResponse.error).toBe('Failed to create database dump')
+    })
+
+    it('should stream data in batches for large tables', async () => {
+        // Simulate a table with more rows than BATCH_SIZE (5000)
+        const largeBatch = Array.from({ length: 5000 }, (_, i) => ({
+            id: i + 1,
+            name: `User${i + 1}`,
+        }))
+        const smallBatch = Array.from({ length: 500 }, (_, i) => ({
+            id: 5001 + i,
+            name: `User${5001 + i}`,
+        }))
+
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'users' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
+            ])
+            .mockResolvedValueOnce([{ count: 5500 }])
+            // First batch of 5000
+            .mockResolvedValueOnce(largeBatch)
+            // Second batch of 500
+            .mockResolvedValueOnce(smallBatch)
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+
+        expect(response).toBeInstanceOf(Response)
+        const dumpText = await response.text()
+
+        // Verify first and last rows from first batch
+        expect(dumpText).toContain("INSERT INTO users VALUES (1, 'User1');")
+        expect(dumpText).toContain(
+            "INSERT INTO users VALUES (5000, 'User5000');"
+        )
+        // Verify rows from second batch
+        expect(dumpText).toContain(
+            "INSERT INTO users VALUES (5001, 'User5001');"
+        )
+        expect(dumpText).toContain(
+            "INSERT INTO users VALUES (5500, 'User5500');"
+        )
+
+        // Verify executeOperation was called with LIMIT/OFFSET queries
+        const calls = vi.mocked(executeOperation).mock.calls
+        // Call 4 (index 3): first batch with OFFSET 0
+        expect(calls[3][0][0].sql).toContain('LIMIT 5000 OFFSET 0')
+        // Call 5 (index 4): second batch with OFFSET 5000
+        expect(calls[4][0][0].sql).toContain('LIMIT 5000 OFFSET 5000')
+    })
+
+    it('should use Transfer-Encoding chunked header for streaming', async () => {
+        vi.mocked(executeOperation).mockResolvedValueOnce([])
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+
+        expect(response.headers.get('Transfer-Encoding')).toBe('chunked')
     })
 })

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -3,6 +3,8 @@ import { StarbaseDBConfiguration } from '../handler'
 import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
+const BATCH_SIZE = 5000
+
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
@@ -16,54 +18,91 @@ export async function dumpDatabaseRoute(
         )
 
         const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
 
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
+        const encoder = new TextEncoder()
+        const stream = new ReadableStream({
+            async start(controller) {
+                try {
+                    controller.enqueue(encoder.encode('SQLite format 3\0'))
 
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
-            }
+                    for (const table of tables) {
+                        // Get table schema
+                        const schemaResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
 
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
+                        if (schemaResult.length) {
+                            const schema = schemaResult[0].sql
+                            controller.enqueue(
+                                encoder.encode(
+                                    `\n-- Table: ${table}\n${schema};\n\n`
+                                )
+                            )
+                        }
 
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
+                        // Get total row count
+                        const countResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT COUNT(*) as count FROM ${table};`,
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
+                        const totalRows = countResult[0]?.count ?? 0
 
-            dumpContent += '\n'
-        }
+                        // Fetch and write data in batches
+                        let offset = 0
+                        while (offset < totalRows) {
+                            const dataResult = await executeOperation(
+                                [
+                                    {
+                                        sql: `SELECT * FROM ${table} LIMIT ${BATCH_SIZE} OFFSET ${offset};`,
+                                    },
+                                ],
+                                dataSource,
+                                config
+                            )
 
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
+                            let batchContent = ''
+                            for (const row of dataResult) {
+                                const values = Object.values(row).map(
+                                    (value) =>
+                                        typeof value === 'string'
+                                            ? `'${(value as string).replace(/'/g, "''")}'`
+                                            : value
+                                )
+                                batchContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
+                            }
+                            controller.enqueue(encoder.encode(batchContent))
+
+                            offset += BATCH_SIZE
+                        }
+
+                        controller.enqueue(encoder.encode('\n'))
+                    }
+
+                    controller.close()
+                } catch (error) {
+                    controller.error(error)
+                }
+            },
+        })
 
         const headers = new Headers({
             'Content-Type': 'application/x-sqlite3',
             'Content-Disposition': 'attachment; filename="database_dump.sql"',
+            'Transfer-Encoding': 'chunked',
         })
 
-        return new Response(blob, { headers })
+        return new Response(stream, { headers })
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -4,13 +4,91 @@ import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
 const BATCH_SIZE = 5000
+const YIELD_INTERVAL = 100
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function* generateDumpChunks(
+    tables: string[],
+    dataSource: DataSource,
+    config: StarbaseDBConfiguration
+): AsyncGenerator<string> {
+    yield 'SQLite format 3\0'
+
+    let rowCounter = 0
+
+    for (const table of tables) {
+        // Get table schema
+        const schemaResult = await executeOperation(
+            [
+                {
+                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
+                },
+            ],
+            dataSource,
+            config
+        )
+
+        if (schemaResult.length) {
+            const schema = schemaResult[0].sql
+            yield `\n-- Table: ${table}\n${schema};\n\n`
+        }
+
+        // Get row count for this table
+        const countResult = await executeOperation(
+            [{ sql: `SELECT COUNT(*) as count FROM ${table};` }],
+            dataSource,
+            config
+        )
+        const totalRows = countResult[0]?.count ?? 0
+
+        // Fetch rows in batches using LIMIT/OFFSET to avoid loading all data into memory
+        let offset = 0
+        while (offset < totalRows) {
+            const batchResult = await executeOperation(
+                [
+                    {
+                        sql: `SELECT * FROM ${table} LIMIT ${BATCH_SIZE} OFFSET ${offset};`,
+                    },
+                ],
+                dataSource,
+                config
+            )
+
+            let batchContent = ''
+            for (const row of batchResult) {
+                const values = Object.values(row).map((value) =>
+                    typeof value === 'string'
+                        ? `'${value.replace(/'/g, "''")}'`
+                        : value
+                )
+                batchContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
+            }
+
+            yield batchContent
+            offset += BATCH_SIZE
+            rowCounter += batchResult.length
+
+            // Yield control periodically to prevent blocking the event loop
+            // and avoid exceeding CF Workers' CPU time limits
+            if (rowCounter >= YIELD_INTERVAL) {
+                rowCounter = 0
+                await sleep(0)
+            }
+        }
+
+        yield '\n'
+    }
+}
 
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        // Get all table names
+        // Get all table names upfront so errors here are caught immediately
         const tablesResult = await executeOperation(
             [{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }],
             dataSource,
@@ -18,80 +96,16 @@ export async function dumpDatabaseRoute(
         )
 
         const tables = tablesResult.map((row: any) => row.name)
-
         const encoder = new TextEncoder()
+        const generator = generateDumpChunks(tables, dataSource, config)
+
         const stream = new ReadableStream({
-            async start(controller) {
-                try {
-                    controller.enqueue(encoder.encode('SQLite format 3\0'))
-
-                    for (const table of tables) {
-                        // Get table schema
-                        const schemaResult = await executeOperation(
-                            [
-                                {
-                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                                },
-                            ],
-                            dataSource,
-                            config
-                        )
-
-                        if (schemaResult.length) {
-                            const schema = schemaResult[0].sql
-                            controller.enqueue(
-                                encoder.encode(
-                                    `\n-- Table: ${table}\n${schema};\n\n`
-                                )
-                            )
-                        }
-
-                        // Get total row count
-                        const countResult = await executeOperation(
-                            [
-                                {
-                                    sql: `SELECT COUNT(*) as count FROM ${table};`,
-                                },
-                            ],
-                            dataSource,
-                            config
-                        )
-                        const totalRows = countResult[0]?.count ?? 0
-
-                        // Fetch and write data in batches
-                        let offset = 0
-                        while (offset < totalRows) {
-                            const dataResult = await executeOperation(
-                                [
-                                    {
-                                        sql: `SELECT * FROM ${table} LIMIT ${BATCH_SIZE} OFFSET ${offset};`,
-                                    },
-                                ],
-                                dataSource,
-                                config
-                            )
-
-                            let batchContent = ''
-                            for (const row of dataResult) {
-                                const values = Object.values(row).map(
-                                    (value) =>
-                                        typeof value === 'string'
-                                            ? `'${(value as string).replace(/'/g, "''")}'`
-                                            : value
-                                )
-                                batchContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-                            }
-                            controller.enqueue(encoder.encode(batchContent))
-
-                            offset += BATCH_SIZE
-                        }
-
-                        controller.enqueue(encoder.encode('\n'))
-                    }
-
+            async pull(controller) {
+                const { value, done } = await generator.next()
+                if (done) {
                     controller.close()
-                } catch (error) {
-                    controller.error(error)
+                } else {
+                    controller.enqueue(encoder.encode(value))
                 }
             },
         })


### PR DESCRIPTION
## Summary

Fixes #59

## Changes

This PR addresses the issue described in #59: Database dumps do not work on large databases

## Testing

- Ran existing test suite — all tests pass
- Ran linter/formatter if available — no new warnings

---
*Automated fix by bounty-hunter agent*