### PR TITLE
fix: database dumps do not work on large databases

### DIFF
--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -20,6 +20,8 @@ export async function dumpDatabaseRoute(
 
         // Iterate through all tables
         for (const table of tables) {
+            // Yield control to event loop to prevent blocking on large datasets
+            await new Promise(resolve => setTimeout(resolve, 0));
             // Get table schema
             const schemaResult = await executeOperation(
                 [


### PR DESCRIPTION
Fixes #59

## Changes
- `src/export/dump.ts`

## Summary
Automated fix for: Database dumps do not work on large databases