### PR TITLE
fix: REST API fails when allowlist is enabled (#52)

### DIFF
--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -70,6 +70,7 @@ export class LiteREST {
             isRaw: false,
             dataSource: this.dataSource,
             config: this.config,
+            isInternal: true,
         })) as any[]
 
         let pkColumns = []

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -196,8 +196,10 @@ export async function executeQuery(opts: {
     isRaw: boolean
     dataSource: DataSource
     config: StarbaseDBConfiguration
+    /** When true, bypasses the allowlist check for internal/system queries (e.g. PRAGMA table_info). */
+    isInternal?: boolean
 }): Promise<QueryResponse> {
-    let { sql, params, isRaw, dataSource, config } = opts
+    let { sql, params, isRaw, dataSource, config, isInternal } = opts
 
     if (!dataSource) {
         console.error('Data source not found.')
@@ -205,12 +207,15 @@ export async function executeQuery(opts: {
     }
 
     // If the allowlist feature is enabled, we should verify the query is allowed before proceeding.
-    await isQueryAllowed({
-        sql: sql,
-        isEnabled: config?.features?.allowlist ?? false,
-        dataSource,
-        config,
-    })
+    // Internal/system queries (e.g. PRAGMA table_info used by LiteREST) bypass the allowlist.
+    if (!isInternal) {
+        await isQueryAllowed({
+            sql: sql,
+            isEnabled: config?.features?.allowlist ?? false,
+            dataSource,
+            config,
+        })
+    }
 
     // If the row level security feature is enabled, we should apply our policies to this SQL statement.
     sql = await applyRLS({


### PR DESCRIPTION
## Problem

When `ENABLE_ALLOWLIST=1`, all REST API endpoints (GET, POST, PATCH, PUT, DELETE) fail because the internal `PRAGMA table_info()` query used to resolve primary key columns gets blocked by the allowlist.

## Root Cause

`LiteREST.getPrimaryKeyColumns()` calls `executeQuery()` which always runs the query through `isQueryAllowed()`. Since `PRAGMA table_info(...)` is not in the allowlist, it throws `Query not allowed`.

## Solution

Added an optional `isInternal` flag to `executeQuery()` that bypasses the allowlist check for system-level queries. `LiteREST.getPrimaryKeyColumns()` now passes `isInternal: true` for its metadata queries.

This is a minimal, targeted fix that:
- Only affects internal system queries (PRAGMA, information_schema) used by LiteREST
- Does not change allowlist behavior for user-facing queries
- Maintains the security model — users cannot bypass the allowlist
- Works for SQLite, PostgreSQL, and MySQL data sources

## Changes

- `src/operation.ts`: Added optional `isInternal` parameter to `executeQuery()`. When true, skips the `isQueryAllowed()` call.
- `src/literest/index.ts`: `getPrimaryKeyColumns()` now passes `isInternal: true`.

Fixes #52
