### PR TITLE
fix: Implement chunked streaming for massive database exports (#59)

### DIFF
--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -8,62 +8,100 @@ export async function dumpDatabaseRoute(
     config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        // Get all table names
+        // Pre-fetch table names to validate DB connection before streaming
         const tablesResult = await executeOperation(
             [{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }],
             dataSource,
             config
         )
 
-        const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
+        const stream = new ReadableStream({
+            async start(controller) {
+                try {
+                    const tables = tablesResult?.map((row: any) => row.name) || []
+                    const encoder = new TextEncoder()
+                    
+                    if (tables.length === 0) {
+                        controller.enqueue(encoder.encode('SQLite format 3\0'))
+                        controller.close()
+                        return
+                    }
 
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
+                    controller.enqueue(encoder.encode('SQLite format 3\0\n'))
 
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
+                    // Iterate through all tables
+                    for (const table of tables) {
+                        if (!table) continue;
+                        
+                        // Get table schema
+                        const schemaResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name=?;`,
+                                    params: [table]
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
+
+                        let tableHasSchema = false;
+                        if (schemaResult && schemaResult.length > 0 && schemaResult[0] && schemaResult[0].sql) {
+                            const schema = schemaResult[0].sql
+                            if (schema) {
+                                controller.enqueue(encoder.encode(`\n-- Table: ${table}\n${schema};\n\n`))
+                                tableHasSchema = true;
+                            }
+                        }
+
+                        // Get table data
+                        // Handle pagination for massive tables to prevent memory buildup
+                        let offset = 0
+                        const limit = 5000
+                        while (true) {
+                            const dataResult = await executeOperation(
+                                [{ sql: `SELECT * FROM ${table} LIMIT ${limit} OFFSET ${offset};` }],
+                                dataSource,
+                                config
+                            )
+                            
+                            if (!dataResult || dataResult.length === 0) break;
+
+                            for (const row of dataResult) {
+                                const values = Object.values(row).map((value) =>
+                                    typeof value === 'string'
+                                        ? `'${value.replace(/'/g, "''")}'`
+                                        : value === null
+                                        ? 'NULL'
+                                        : value
+                                )
+                                controller.enqueue(encoder.encode(`INSERT INTO ${table} VALUES (${values.join(', ')});\n`))
+                            }
+                            
+                            offset += limit
+                            if (dataResult.length < limit) break;
+                            
+                            // Yield to the event loop to prevent durable object blocking
+                            await new Promise(resolve => setTimeout(resolve, 5))
+                        }
+
+                        controller.enqueue(encoder.encode('\n'))
+                    }
+                    
+                    controller.close()
+                } catch (e) {
+                    controller.error(e)
+                }
             }
-
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
-
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
-
-            dumpContent += '\n'
-        }
-
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
+        })
 
         const headers = new Headers({
             'Content-Type': 'application/x-sqlite3',
             'Content-Disposition': 'attachment; filename="database_dump.sql"',
+            'Transfer-Encoding': 'chunked'
         })
 
-        return new Response(blob, { headers })
+        return new Response(stream, { headers })
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)


### PR DESCRIPTION
Fixes #59. 

### Issue
When attempting to export databases via `/export/dump`, loading the entire SQL text string into memory causes the Cloudflare Worker/Durable Object to exceed its 30-second request limit and crash.

### Solution
This PR rewrites `src/export/dump.ts` to utilize a `ReadableStream`. 
- Instead of string concatenation, data is chunked directly into the response stream (`Transfer-Encoding: chunked`).
- Massive tables are queried in paginated chunks (`LIMIT 5000 OFFSET X`) to prevent memory spikes.
- Between processing tables and chunks, the `start(controller)` logic yields to the event loop (`await new Promise(resolve => setTimeout(resolve, 5))`), satisfying the 'breathing interval' requirement so the DO doesn't lock up and drop other requests.