### PR TITLE
fix(export): stream database dump to prevent memory exhaustion on large databases

### DIFF
--- a/src/export/dump.test.ts
+++ b/src/export/dump.test.ts
@@ -40,17 +40,26 @@ beforeEach(() => {
 
 describe('Database Dump Module', () => {
     it('should return a database dump when tables exist', async () => {
+        // Pagination logic: if rows.length < BATCH_SIZE (1000), stop looping.
+        // Both tables return 2 rows → each table needs only 1 batch call.
+        //
+        // Call order:
+        //   0: table list → ['users', 'orders']
+        //   1: users schema
+        //   2: users data batch (2 rows < 1000 → stops)
+        //   3: orders schema
+        //   4: orders data batch (2 rows < 1000 → stops)
         vi.mocked(executeOperation)
             .mockResolvedValueOnce([{ name: 'users' }, { name: 'orders' }])
             .mockResolvedValueOnce([
-                { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
+                { sql: 'CREATE TABLE users (id INTEGER, name TEXT)' },
             ])
             .mockResolvedValueOnce([
                 { id: 1, name: 'Alice' },
                 { id: 2, name: 'Bob' },
             ])
             .mockResolvedValueOnce([
-                { sql: 'CREATE TABLE orders (id INTEGER, total REAL);' },
+                { sql: 'CREATE TABLE orders (id INTEGER, total REAL)' },
             ])
             .mockResolvedValueOnce([
                 { id: 1, total: 99.99 },
@@ -68,16 +77,17 @@ describe('Database Dump Module', () => {
         )
 
         const dumpText = await response.text()
+        expect(dumpText).toContain('CREATE TABLE users (id INTEGER, name TEXT)')
+        expect(dumpText).toContain('INSERT INTO "users" VALUES (1, \'Alice\');')
+        expect(dumpText).toContain('INSERT INTO "users" VALUES (2, \'Bob\');')
         expect(dumpText).toContain(
-            'CREATE TABLE users (id INTEGER, name TEXT);'
+            'CREATE TABLE orders (id INTEGER, total REAL)'
         )
-        expect(dumpText).toContain("INSERT INTO users VALUES (1, 'Alice');")
-        expect(dumpText).toContain("INSERT INTO users VALUES (2, 'Bob');")
-        expect(dumpText).toContain(
-            'CREATE TABLE orders (id INTEGER, total REAL);'
-        )
-        expect(dumpText).toContain('INSERT INTO orders VALUES (1, 99.99);')
-        expect(dumpText).toContain('INSERT INTO orders VALUES (2, 49.5);')
+        expect(dumpText).toContain('INSERT INTO "orders" VALUES (1, 99.99);')
+        expect(dumpText).toContain('INSERT INTO "orders" VALUES (2, 49.5);')
+        // dump must be wrapped in a transaction
+        expect(dumpText).toContain('BEGIN TRANSACTION;')
+        expect(dumpText).toContain('COMMIT;')
     })
 
     it('should handle empty databases (no tables)', async () => {
@@ -90,14 +100,18 @@ describe('Database Dump Module', () => {
             'application/x-sqlite3'
         )
         const dumpText = await response.text()
-        expect(dumpText).toBe('SQLite format 3\0')
+        // Should still contain header comment and transaction markers
+        expect(dumpText).toContain('StarbaseDB SQL dump')
+        expect(dumpText).toContain('BEGIN TRANSACTION;')
+        expect(dumpText).toContain('COMMIT;')
     })
 
     it('should handle databases with tables but no data', async () => {
+        // data batch returns 0 rows → exits immediately
         vi.mocked(executeOperation)
             .mockResolvedValueOnce([{ name: 'users' }])
             .mockResolvedValueOnce([
-                { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
+                { sql: 'CREATE TABLE users (id INTEGER, name TEXT)' },
             ])
             .mockResolvedValueOnce([])
 
@@ -105,18 +119,17 @@ describe('Database Dump Module', () => {
 
         expect(response).toBeInstanceOf(Response)
         const dumpText = await response.text()
-        expect(dumpText).toContain(
-            'CREATE TABLE users (id INTEGER, name TEXT);'
-        )
-        expect(dumpText).not.toContain('INSERT INTO users VALUES')
+        expect(dumpText).toContain('CREATE TABLE users (id INTEGER, name TEXT)')
+        expect(dumpText).not.toContain('INSERT INTO')
     })
 
     it('should escape single quotes properly in string values', async () => {
         vi.mocked(executeOperation)
             .mockResolvedValueOnce([{ name: 'users' }])
             .mockResolvedValueOnce([
-                { sql: 'CREATE TABLE users (id INTEGER, bio TEXT);' },
+                { sql: 'CREATE TABLE users (id INTEGER, bio TEXT)' },
             ])
+            // 1 row → length 1 < 1000 → stops after first batch
             .mockResolvedValueOnce([{ id: 1, bio: "Alice's adventure" }])
 
         const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
@@ -124,14 +137,85 @@ describe('Database Dump Module', () => {
         expect(response).toBeInstanceOf(Response)
         const dumpText = await response.text()
         expect(dumpText).toContain(
-            "INSERT INTO users VALUES (1, 'Alice''s adventure');"
+            "INSERT INTO \"users\" VALUES (1, 'Alice''s adventure');"
         )
     })
 
-    it('should return a 500 response when an error occurs', async () => {
+    it('should handle NULL values correctly', async () => {
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'users' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE users (id INTEGER, name TEXT)' },
+            ])
+            .mockResolvedValueOnce([{ id: 1, name: null }])
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+        const dumpText = await response.text()
+        expect(dumpText).toContain('INSERT INTO "users" VALUES (1, NULL);')
+    })
+
+    it('should handle boolean values as 1/0', async () => {
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'flags' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE flags (id INTEGER, active INTEGER)' },
+            ])
+            .mockResolvedValueOnce([
+                { id: 1, active: true },
+                { id: 2, active: false },
+            ])
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+        const dumpText = await response.text()
+        expect(dumpText).toContain('INSERT INTO "flags" VALUES (1, 1);')
+        expect(dumpText).toContain('INSERT INTO "flags" VALUES (2, 0);')
+    })
+
+    it('should paginate large tables across multiple batches', async () => {
+        // Simulate a table with exactly BATCH_SIZE (1000) rows in first batch,
+        // then 500 rows in second batch (signals end-of-data since 500 < 1000).
+        const firstBatch = Array.from({ length: 1000 }, (_, i) => ({
+            id: i + 1,
+            val: `row${i + 1}`,
+        }))
+        const secondBatch = Array.from({ length: 500 }, (_, i) => ({
+            id: 1001 + i,
+            val: `row${1001 + i}`,
+        }))
+
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'big_table' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE big_table (id INTEGER, val TEXT)' },
+            ])
+            // first batch: full 1000 rows → pagination continues
+            .mockResolvedValueOnce(firstBatch)
+            // second batch: 500 rows < 1000 → stops pagination
+            .mockResolvedValueOnce(secondBatch)
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+        const dumpText = await response.text()
+
+        // Rows from both batches should appear
+        expect(dumpText).toContain(
+            'INSERT INTO "big_table" VALUES (1, \'row1\');'
+        )
+        expect(dumpText).toContain(
+            'INSERT INTO "big_table" VALUES (1000, \'row1000\');'
+        )
+        expect(dumpText).toContain(
+            'INSERT INTO "big_table" VALUES (1001, \'row1001\');'
+        )
+        expect(dumpText).toContain(
+            'INSERT INTO "big_table" VALUES (1500, \'row1500\');'
+        )
+    })
+
+    it('should return a 500 response when an error occurs during setup', async () => {
         const consoleErrorMock = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {})
+        // Reject the very first call (table list) so the outer try-catch fires
         vi.mocked(executeOperation).mockRejectedValue(
             new Error('Database Error')
         )

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -3,67 +3,168 @@ import { StarbaseDBConfiguration } from '../handler'
 import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
+/**
+ * Batch size for paginated row reads. Keeping it at 1000 rows per query
+ * avoids large per-query allocations while still being efficient.
+ */
+const BATCH_SIZE = 1_000
+
+/**
+ * Yield to the event loop so other pending micro-tasks (e.g. inbound requests
+ * to the Durable Object) can run between batches. Without this the DO can lock
+ * up under load while an export is in progress.
+ */
+function breathe(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * Escape a SQL identifier (table / column name) by wrapping it in double
+ * quotes and doubling any embedded double-quote characters.
+ */
+function quoteIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`
+}
+
+/**
+ * Produce a SQL literal for an arbitrary row value.
+ * - strings  →  single-quoted with internal quotes doubled
+ * - null      →  NULL
+ * - boolean   →  1 / 0
+ * - everything else → raw value (numbers, bigint …)
+ */
+function sqlValue(value: unknown): string {
+    if (value === null || value === undefined) return 'NULL'
+    if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`
+    if (typeof value === 'boolean') return value ? '1' : '0'
+    return String(value)
+}
+
+/**
+ * Stream a full SQL dump of the database.
+ *
+ * Key improvements over the original implementation:
+ *   1. Uses a ReadableStream so bytes are flushed to the client as they are
+ *      produced rather than accumulated in a single in-memory string.
+ *   2. Reads each table in paginated batches (LIMIT/OFFSET) so a single large
+ *      table never occupies more than BATCH_SIZE rows in memory at once.
+ *   3. Calls `breathe()` between batches to yield the event loop and prevent
+ *      the Durable Object from blocking other incoming requests.
+ *   4. Uses parameterised queries / quoted identifiers everywhere to avoid
+ *      SQL-injection in table / column names that contain special characters.
+ */
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        // Get all table names
         const tablesResult = await executeOperation(
-            [{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }],
+            [
+                {
+                    sql: "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;",
+                },
+            ],
             dataSource,
             config
         )
 
-        const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
+        const tables: string[] = tablesResult.map((row: any) => row.name)
 
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
+        const encoder = new TextEncoder()
 
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
-            }
+        const stream = new ReadableStream({
+            async start(controller) {
+                try {
+                    // Write the conventional SQL dump header comment so consumers
+                    // know this is a plain-text SQL script, not a binary SQLite file.
+                    controller.enqueue(
+                        encoder.encode(
+                            '-- StarbaseDB SQL dump\n-- Generated: ' +
+                                new Date().toISOString() +
+                                '\n\nBEGIN TRANSACTION;\n\n'
+                        )
+                    )
 
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
+                    for (const table of tables) {
+                        // --- Schema ---
+                        const schemaResult = await executeOperation(
+                            [
+                                {
+                                    sql: 'SELECT sql FROM sqlite_master WHERE type=? AND name=?;',
+                                    params: ['table', table],
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
 
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
+                        if (schemaResult.length && schemaResult[0].sql) {
+                            const ddl: string = schemaResult[0].sql
+                            controller.enqueue(
+                                encoder.encode(
+                                    `-- Table: ${table}\n${ddl};\n\n`
+                                )
+                            )
+                        }
 
-            dumpContent += '\n'
-        }
+                        // --- Data (paginated) ---
+                        let offset = 0
+                        while (true) {
+                            const rows = await executeOperation(
+                                [
+                                    {
+                                        sql: `SELECT * FROM ${quoteIdentifier(table)} LIMIT ? OFFSET ?;`,
+                                        params: [BATCH_SIZE, offset],
+                                    },
+                                ],
+                                dataSource,
+                                config
+                            )
 
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
+                            if (!rows || rows.length === 0) break
+
+                            for (const row of rows) {
+                                const values = Object.values(row).map(sqlValue)
+                                controller.enqueue(
+                                    encoder.encode(
+                                        `INSERT INTO ${quoteIdentifier(table)} VALUES (${values.join(', ')});\n`
+                                    )
+                                )
+                            }
+
+                            offset += rows.length
+
+                            // Yield to the event loop after each batch so
+                            // other DO requests can be serviced.
+                            await breathe()
+
+                            // If we received fewer rows than the batch size we
+                            // have reached the end of the table.
+                            if (rows.length < BATCH_SIZE) break
+                        }
+
+                        controller.enqueue(encoder.encode('\n'))
+
+                        // Yield between tables as well.
+                        await breathe()
+                    }
+
+                    controller.enqueue(encoder.encode('COMMIT;\n'))
+                    controller.close()
+                } catch (innerError: any) {
+                    console.error('Database Dump Stream Error:', innerError)
+                    controller.error(innerError)
+                }
+            },
+        })
 
         const headers = new Headers({
             'Content-Type': 'application/x-sqlite3',
             'Content-Disposition': 'attachment; filename="database_dump.sql"',
+            'Transfer-Encoding': 'chunked',
         })
 
-        return new Response(blob, { headers })
+        return new Response(stream, { headers })
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)


### PR DESCRIPTION
## Summary

Fixes #59.

The current `/export/dump` implementation accumulates the entire database into a single in-memory string before returning a `Blob`. On a 10 GB Durable Object database this means:

1. **Memory exhaustion** — the entire dump lives in RAM at once
2. **DO CPU lock-up** — the synchronous string-building loop starves other requests
3. **30-second wall-clock timeout** — long exports never complete

This PR replaces that approach with a `ReadableStream` + paginated batch reads.

## Changes

### `src/export/dump.ts`

- **Streaming response** — returns `new Response(stream, headers)` where `stream` is a `ReadableStream`. Bytes are flushed to the client as they are produced — no full dump ever lives in memory.
- **Paginated batch reads** — each table is read in batches of `BATCH_SIZE = 1000` rows (`LIMIT ? OFFSET ?`). Only one batch is in memory at a time.
- **Breathing intervals** — `breathe()` (a zero-delay `setTimeout`) yields to the event loop after every batch and between tables, allowing other Durable Object requests to be serviced during a long-running export.
- **Parameterised schema query** — schema lookup uses `params: ['table', name]` instead of string interpolation.
- **`quoteIdentifier()`** — double-quote escapes table/column names to handle names with special characters safely.
- **Transaction wrapping** — output starts with `BEGIN TRANSACTION;` and ends with `COMMIT;` for correct re-import.
- **Correct SQL literals** for `NULL` and `boolean` values (`NULL`, `1`/`0`).

### `src/export/dump.test.ts`

8 unit tests covering:
- Multi-table dump (headers, schema DDL, INSERT statements, transaction markers)
- Empty database (no tables)
- Table with no rows
- Single-quote escaping
- `NULL` values
- `boolean` values mapped to `1`/`0`
- **Pagination across two batches** (first batch exactly 1000 rows, second batch 500 rows)
- Error path returning HTTP 500

## Test Results

```
✓ src/export/dump.test.ts (8 tests) 25ms
```

/claim #59