### PR TITLE
feat(plugin): add pull-replicator scaffold for external sync (#72)

### DIFF
--- a/plugins/pull-replicator/README.md
+++ b/plugins/pull-replicator/README.md
@@ -1,0 +1,6 @@
+# Pull Replicator Plugin (Issue #72 scaffold)
+
+Initial control-plane slice for replication:
+- `tmp_replication_jobs` configuration table
+- `tmp_replication_runs` run-tracking table
+- health endpoint `/api/plugins/pull-replicator/health`

--- a/plugins/pull-replicator/index.test.ts
+++ b/plugins/pull-replicator/index.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StarbaseApp } from '../../src/handler'
+import { DataSource } from '../../src/types'
+import { PullReplicatorPlugin } from './index'
+
+let plugin: PullReplicatorPlugin
+let mockDataSource: DataSource
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockDataSource = { rpc: { executeQuery: vi.fn().mockResolvedValue([]) } } as unknown as DataSource
+	plugin = new PullReplicatorPlugin()
+})
+
+describe('PullReplicatorPlugin', () => {
+	it('register creates replication tables in middleware', async () => {
+		const mockApp = {
+			use: vi.fn((middleware) => middleware({ get: vi.fn(() => mockDataSource) }, vi.fn())),
+			get: vi.fn(),
+		} as unknown as StarbaseApp
+
+		await plugin.register(mockApp)
+
+		expect(mockDataSource.rpc.executeQuery).toHaveBeenCalledTimes(2)
+		expect(mockDataSource.rpc.executeQuery).toHaveBeenNthCalledWith(1, {
+			sql: expect.stringContaining('tmp_replication_jobs'),
+			params: [],
+		})
+		expect(mockDataSource.rpc.executeQuery).toHaveBeenNthCalledWith(2, {
+			sql: expect.stringContaining('tmp_replication_runs'),
+			params: [],
+		})
+	})
+})

--- a/plugins/pull-replicator/index.ts
+++ b/plugins/pull-replicator/index.ts
@@ -1,0 +1,60 @@
+import { StarbaseApp } from '../../src/handler'
+import { StarbasePlugin } from '../../src/plugin'
+import { DataSource } from '../../src/types'
+
+const SQL = {
+	CREATE_REPLICATION_JOBS: `
+		CREATE TABLE IF NOT EXISTS tmp_replication_jobs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			source_name TEXT NOT NULL,
+			table_name TEXT NOT NULL,
+			cursor_column TEXT DEFAULT 'updated_at',
+			last_cursor_value TEXT,
+			status TEXT NOT NULL DEFAULT 'idle',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`,
+	CREATE_REPLICATION_RUNS: `
+		CREATE TABLE IF NOT EXISTS tmp_replication_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			job_id INTEGER NOT NULL,
+			rows_synced INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL,
+			error_message TEXT,
+			started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			finished_at DATETIME,
+			FOREIGN KEY(job_id) REFERENCES tmp_replication_jobs(id)
+		)
+	`,
+}
+
+export class PullReplicatorPlugin extends StarbasePlugin {
+	private dataSource?: DataSource
+
+	constructor() {
+		super('starbasedb:pull-replicator')
+	}
+
+	override async register(app: StarbaseApp) {
+		app.use(async (c, next) => {
+			this.dataSource = c?.get('dataSource')
+			await this.ensureTables(this.dataSource)
+			await next()
+		})
+
+		app.get('/api/plugins/pull-replicator/health', (c) => {
+			return c.json({
+				ok: true,
+				plugin: this.name,
+				hasDataSource: !!this.dataSource,
+			})
+		})
+	}
+
+	private async ensureTables(dataSource?: DataSource) {
+		if (!dataSource) return
+		await dataSource.rpc.executeQuery({ sql: SQL.CREATE_REPLICATION_JOBS, params: [] })
+		await dataSource.rpc.executeQuery({ sql: SQL.CREATE_REPLICATION_RUNS, params: [] })
+	}
+}

--- a/plugins/pull-replicator/meta.json
+++ b/plugins/pull-replicator/meta.json
@@ -1,0 +1,1 @@
+{"name":"pull-replicator","description":"Replication control-plane scaffold","version":"0.1.0"}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { QueryLogPlugin } from '../plugins/query-log'
 import { StatsPlugin } from '../plugins/stats'
 import { CronPlugin } from '../plugins/cron'
 import { InterfacePlugin } from '../plugins/interface'
+import { PullReplicatorPlugin } from '../plugins/pull-replicator'
 
 export { StarbaseDBDurableObject } from './do'
 
@@ -225,6 +226,7 @@ export default {
                 cdcPlugin,
                 cronPlugin,
                 new StatsPlugin(),
+                new PullReplicatorPlugin(),
                 interfacePlugin,
             ] satisfies StarbasePlugin[]
 


### PR DESCRIPTION
/claim #72

This PR delivers a concrete first implementation slice for issue #72 by adding a replication control-plane plugin scaffold.

### Implemented
- New plugin: `plugins/pull-replicator`
- Creates replication control tables automatically:
  - `tmp_replication_jobs`
  - `tmp_replication_runs`
- Registers health endpoint:
  - `GET /api/plugins/pull-replicator/health`
- Wires plugin into runtime in `src/index.ts`
- Includes unit test for table bootstrap behavior

### Why this PR-first scope
Issue #72 is broad and has a history of abandoned attempts. This PR intentionally lands a reviewable, production-usable foundation (schema + lifecycle wiring) that follow-up PRs can extend with connector adapters, checkpointed pull execution, and upsert conflict strategies.

### Follow-up slices
1. Adapter interface + concrete source connectors
2. Checkpointed incremental pull execution
3. Admin trigger/status/retry endpoints + demo video
