### PR TITLE
fix: streaming database dump with pagination for large databases

### DIFF
--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -3,69 +3,125 @@ import { StarbaseDBConfiguration } from '../handler'
 import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
+const BATCH_SIZE = 500
+
+function escapeValue(value: unknown): string {
+    if (value === null || value === undefined) return 'NULL'
+    if (typeof value === 'boolean') return value ? '1' : '0'
+    if (typeof value === 'number' || typeof value === 'bigint')
+        return String(value)
+    return `'${String(value).replace(/'/g, "''")}'`
+}
+
+function quoteIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`
+}
+
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
 ): Promise<Response> {
+    let tables: { name: string; sql: string | null }[]
+
     try {
-        // Get all table names
         const tablesResult = await executeOperation(
-            [{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }],
+            [
+                {
+                    sql: `SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name;`,
+                },
+            ],
             dataSource,
             config
         )
-
-        const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
-
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
-
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
-            }
-
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
-
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
-
-            dumpContent += '\n'
-        }
-
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
-
-        const headers = new Headers({
-            'Content-Type': 'application/x-sqlite3',
-            'Content-Disposition': 'attachment; filename="database_dump.sql"',
-        })
-
-        return new Response(blob, { headers })
+        tables = tablesResult.map((row: any) => ({
+            name: row.name as string,
+            sql: (row.sql as string | null) ?? null,
+        }))
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)
     }
+
+    const encoder = new TextEncoder()
+
+    const stream = new ReadableStream({
+        async start(controller) {
+            function write(text: string) {
+                controller.enqueue(encoder.encode(text))
+            }
+
+            try {
+                write('BEGIN TRANSACTION;\n\n')
+
+                for (const table of tables) {
+                    const quotedTable = quoteIdentifier(table.name)
+
+                    if (table.sql) {
+                        write(`${table.sql};\n\n`)
+                    }
+
+                    const schemaRows = await executeOperation(
+                        [{ sql: `PRAGMA table_info(${quotedTable});` }],
+                        dataSource,
+                        config
+                    )
+
+                    const columns = schemaRows.map((r: any) => r.name as string)
+                    const quotedColumns = columns
+                        .map(quoteIdentifier)
+                        .join(', ')
+
+                    let offset = 0
+
+                    while (true) {
+                        const batch = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT * FROM ${quotedTable} ORDER BY rowid LIMIT ${BATCH_SIZE} OFFSET ${offset};`,
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
+
+                        for (const row of batch) {
+                            const values = columns
+                                .map((col) =>
+                                    escapeValue((row as any)[col])
+                                )
+                                .join(', ')
+                            write(
+                                `INSERT INTO ${quotedTable} (${quotedColumns}) VALUES (${values});\n`
+                            )
+                        }
+
+                        offset += batch.length
+
+                        await new Promise<void>((resolve) =>
+                            setTimeout(resolve, 0)
+                        )
+
+                        if (batch.length < BATCH_SIZE) break
+                    }
+
+                    write('\n')
+                }
+
+                write('COMMIT;\n')
+                controller.close()
+            } catch (err: any) {
+                console.error('Database Dump Stream Error:', err)
+                controller.error(err)
+            }
+        },
+    })
+
+    return new Response(stream, {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/x-sql',
+            'Content-Disposition':
+                'attachment; filename="database_dump.sql"',
+        },
+    })
 }


### PR DESCRIPTION
/claim #59

## Fix: Large database dumps fail due to memory and timeout limits

This PR replaces the current in-memory dump implementation with a streaming-based approach to support large databases reliably.

### Problem

The existing `/export/dump` implementation:

* loads entire tables into memory (`executeOperation → cursor.toArray()`)
* builds a full dump string before responding
* fails for large databases due to memory limits and timeouts

### Solution

This PR introduces a minimal, streaming-based fix:

* Uses `ReadableStream` to stream dump output progressively
* Fetches rows in batches using `LIMIT/OFFSET`
* Adds `ORDER BY rowid` to ensure stable pagination
* Includes breathing intervals to prevent Durable Object blocking
* Keeps all changes scoped to `src/export/dump.ts`

### Key Benefits

* Works for arbitrarily large databases
* Avoids memory overflow
* Avoids timeout failures
* No new infrastructure required
* Minimal diff, no changes to shared utilities

### Example Usage

```bash id="0wr7o9"
curl --location 'https://<your-worker>/export/dump' \
--header 'Authorization: Bearer <token>' \
--output database_dump.sql
```

### Notes

* Does not modify `executeOperation` or other export routes (JSON/CSV remain unchanged)
* Designed as a safe, incremental improvement without introducing async jobs or R2 dependencies
