### PR TITLE
feat: add event-driven replication plugin using afterQuery hooks

### DIFF
--- a/plugins/replication/README.md
+++ b/plugins/replication/README.md
@@ -1,0 +1,79 @@
+# Replication Plugin
+
+Propagates write queries (`INSERT`, `UPDATE`, `DELETE`) from a primary StarbaseDB instance to one or more peer instances in the background.
+
+## How it works
+
+The plugin hooks into the `afterQuery` lifecycle. When a write is detected, the original SQL is forwarded to each configured replica via `fetch`, wrapped in `ctx.waitUntil` so replication never adds latency to the primary response.
+
+Unlike the CDC plugin, which captures change events for observability and downstream consumers, this plugin focuses on **cross-instance write propagation** — keeping peer StarbaseDB instances in sync with the primary.
+
+Replication is implemented via query interception rather than polling, consistent with StarbaseDB's plugin architecture and Cloudflare Worker runtime constraints.
+
+```
+Client → StarbaseDB (primary)
+              │
+              ├─ executes query, returns result immediately
+              │
+              └─ afterQuery → waitUntil (non-blocking)
+                    ├─ replica 1: POST /query
+                    └─ replica 2: POST /query
+```
+
+## Configuration
+
+| Option      | Type       | Required | Description                                                    |
+|-------------|------------|----------|----------------------------------------------------------------|
+| `replicas`  | `string[]` | ✅        | URLs of peer StarbaseDB instances to receive replicated writes |
+| `authToken` | `string`   | ✅        | Bearer token for replica instances (see Security below)        |
+| `tables`    | `string[]` | ❌        | Allowlist of table names to replicate. Omit to replicate all.  |
+
+### Security: `authToken`
+
+Each replication request is sent as:
+
+```
+Authorization: Bearer <authToken>
+```
+
+This must match the `ADMIN_AUTHORIZATION_TOKEN` configured on each replica instance. Without it, replicas will reject incoming writes. Keep this value out of source control — use `wrangler secret` or environment variables.
+
+## Usage
+
+In `src/index.ts`, register the plugin and inject the `ExecutionContext`:
+
+```ts
+import { ReplicationPlugin } from '../plugins/replication'
+
+const replicationPlugin = new ReplicationPlugin({
+    replicas: ['https://my-replica.example.workers.dev'],
+    authToken: 'your-replica-admin-token',
+    // Optional: only replicate writes to specific tables
+    // tables: ['users', 'orders'],
+})
+
+// Inject ExecutionContext so the plugin can schedule background work
+replicationPlugin.onEvent(ctx)
+
+const plugins = [
+    // ...other plugins
+    replicationPlugin,
+] satisfies StarbasePlugin[]
+```
+
+## Guarantees
+
+| Property | Behaviour |
+|---|---|
+| **Non-blocking** | Replication runs via `ctx.waitUntil` — zero impact on primary response time |
+| **Safe failure** | A replica being unreachable is logged; the primary query result is unaffected |
+| **Parallel fanout** | `Promise.allSettled` — one failing replica never blocks others |
+| **Fail-open parsing** | If SQL cannot be parsed, the query is skipped (not replicated), never crashes |
+| **Precise filtering** | If table filtering is configured and the target table cannot be determined, the query is skipped rather than forwarded blindly |
+
+## Notes
+
+- Replicas must be running StarbaseDB instances with a valid `ADMIN_AUTHORIZATION_TOKEN`
+- Schema must exist on replicas before replication begins — this plugin replicates DML, not DDL
+- Only `INSERT`, `UPDATE`, `DELETE`, and `REPLACE` are forwarded; `SELECT` is ignored
+- Ensure replica URLs do not point back to the primary instance to avoid replication loops

--- a/plugins/replication/index.ts
+++ b/plugins/replication/index.ts
@@ -1,0 +1,199 @@
+import { StarbasePlugin } from '../../src/plugin'
+import type { StarbaseApp } from '../../src/handler'
+import type { DataSource } from '../../src/types'
+import { Parser } from 'node-sql-parser'
+
+// Defined as a structural type rather than referencing the global directly,
+// ensuring compatibility across TypeScript configurations and build targets.
+type ExecutionContext = {
+    waitUntil: (promise: Promise<unknown>) => void
+}
+
+export interface ReplicationConfig {
+    /**
+     * One or more peer StarbaseDB URLs to replicate writes to.
+     * e.g. ["https://replica1.example.workers.dev"]
+     */
+    replicas: string[]
+
+    /**
+     * Authorization token sent with each replication request.
+     * Must match the ADMIN_AUTHORIZATION_TOKEN on each replica instance.
+     * Prevents unauthorized instances from accepting forwarded writes.
+     */
+    authToken: string
+
+    /**
+     * Optional allowlist of table names to replicate.
+     * If omitted, all write operations are replicated.
+     * If provided, only mutations to listed tables are forwarded.
+     */
+    tables?: string[]
+}
+
+const MUTATION_TYPES = new Set(['insert', 'update', 'delete', 'replace'])
+
+const parser = new Parser()
+
+/**
+ * ReplicationPlugin
+ *
+ * Intercepts write queries (INSERT, UPDATE, DELETE) via the afterQuery hook
+ * and forwards them to one or more peer StarbaseDB instances asynchronously.
+ *
+ * Unlike the CDC plugin, which captures change events for observability and
+ * downstream consumers, this plugin focuses on cross-instance write propagation
+ * to keep peer StarbaseDB instances in sync.
+ *
+ * Replication is implemented via query interception rather than polling,
+ * consistent with StarbaseDB's plugin architecture and Cloudflare Worker
+ * runtime constraints.
+ */
+export class ReplicationPlugin extends StarbasePlugin {
+    private replicas: string[]
+    private tables: Set<string> | null
+    private authToken: string
+
+    // ctx is stored via onEvent(), following the CDC plugin pattern.
+    // Required to schedule background work via waitUntil without blocking
+    // the primary request response.
+    private ctx: ExecutionContext | null = null
+
+    constructor(config: ReplicationConfig) {
+        // requiresAuth: false because replication runs post-query internally,
+        // not as a user-facing route or external request handler.
+        super('replication', { requiresAuth: false })
+        this.replicas = config.replicas
+        this.authToken = config.authToken
+        this.tables = config.tables ? new Set(config.tables) : null
+    }
+
+    /**
+     * Called once at startup with the Worker ExecutionContext.
+     * Mirrors the CDC plugin pattern: ctx is injected externally rather
+     * than assumed to be present in the afterQuery signature.
+     *
+     * Usage in src/index.ts:
+     *   replicationPlugin.onEvent(ctx)
+     */
+    onEvent(ctx: ExecutionContext): void {
+        this.ctx = ctx
+    }
+
+    async register(_app: StarbaseApp): Promise<void> {
+        // No HTTP routes needed — this plugin operates purely via query hooks.
+    }
+
+    async beforeQuery(opts: {
+        sql: string
+        params?: unknown[]
+        dataSource?: DataSource
+        config?: unknown
+    }): Promise<{ sql: string; params?: unknown[] }> {
+        return { sql: opts.sql, params: opts.params }
+    }
+
+    async afterQuery(opts: {
+        sql: string
+        result: unknown
+        isRaw: boolean
+        dataSource?: DataSource
+        config?: unknown
+    }): Promise<unknown> {
+        const { sql } = opts
+
+        // Without a stored ctx we cannot schedule background work safely.
+        // Degrade gracefully rather than blocking or erroring.
+        if (!this.ctx || this.replicas.length === 0) {
+            return opts.result
+        }
+
+        let statementType: string
+        let affectedTable: string | null = null
+
+        try {
+            const ast = parser.astify(sql)
+            const node = Array.isArray(ast) ? ast[0] : ast
+            statementType = (node?.type ?? '').toLowerCase()
+
+            if (statementType === 'insert' || statementType === 'replace') {
+                affectedTable =
+                    (node as { table?: { table?: string } }).table?.table ??
+                    null
+            } else if (statementType === 'update') {
+                const tables = (
+                    node as { table?: Array<{ table?: string }> }
+                ).table
+                affectedTable = tables?.[0]?.table ?? null
+            } else if (statementType === 'delete') {
+                const from = (
+                    node as { from?: Array<{ table?: string }> }
+                ).from
+                affectedTable = from?.[0]?.table ?? null
+            }
+        } catch {
+            // Fail-open strategy: if SQL cannot be parsed, skip replication.
+            // Replication must never affect primary DB correctness or availability.
+            return opts.result
+        }
+
+        if (!MUTATION_TYPES.has(statementType)) {
+            return opts.result
+        }
+
+        // Apply table filter. If filtering is configured and we cannot
+        // determine the affected table (parse edge case), skip replication
+        // rather than forwarding blindly to unintended replicas.
+        if (this.tables !== null) {
+            if (!affectedTable || !this.tables.has(affectedTable)) {
+                return opts.result
+            }
+        }
+
+        // Schedule replication in the background via waitUntil so it has
+        // zero impact on primary request latency — a hard requirement in
+        // Cloudflare Workers where async work outside waitUntil is not
+        // guaranteed to complete after the response is sent.
+        this.ctx.waitUntil(this.replicateToAll(sql))
+
+        return opts.result
+    }
+
+    private async replicateToAll(sql: string): Promise<void> {
+        // Promise.allSettled ensures one failing replica never blocks others.
+        await Promise.allSettled(
+            this.replicas.map((replica) => this.replicateTo(replica, sql))
+        )
+    }
+
+    private async replicateTo(replicaUrl: string, sql: string): Promise<void> {
+        try {
+            const endpoint = replicaUrl.replace(/\/$/, '') + '/query'
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${this.authToken}`,
+                },
+                body: JSON.stringify({ sql, params: [] }),
+            })
+
+            if (!response.ok) {
+                console.error(
+                    `[ReplicationPlugin] Failed to replicate to ${replicaUrl}: HTTP ${response.status}`
+                )
+            } else {
+                console.debug(
+                    `[ReplicationPlugin] Replicated to ${replicaUrl}`
+                )
+            }
+        } catch (err) {
+            // Log but never throw — a replication failure must not surface
+            // to the caller or affect the primary query result.
+            console.error(
+                `[ReplicationPlugin] Error replicating to ${replicaUrl}:`,
+                err
+            )
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { QueryLogPlugin } from '../plugins/query-log'
 import { StatsPlugin } from '../plugins/stats'
 import { CronPlugin } from '../plugins/cron'
 import { InterfacePlugin } from '../plugins/interface'
+import { ReplicationPlugin } from '../plugins/replication'
 
 export { StarbaseDBDurableObject } from './do'
 
@@ -95,8 +96,8 @@ export default {
             const stub =
                 region !== RegionLocationHint.AUTO
                     ? env.DATABASE_DURABLE_OBJECT.get(id, {
-                          locationHint: region as DurableObjectLocationHint,
-                      })
+                        locationHint: region as DurableObjectLocationHint,
+                    })
                     : env.DATABASE_DURABLE_OBJECT.get(id)
 
             // Create a new RPC Session on the Durable Object.
@@ -113,8 +114,8 @@ export default {
                     ? source.toLowerCase().trim() === 'external'
                         ? 'external'
                         : source.toLowerCase().trim() === 'hyperdrive'
-                          ? 'hyperdrive'
-                          : 'internal'
+                            ? 'hyperdrive'
+                            : 'internal'
                     : 'internal',
                 cache: request.headers.get('X-Starbase-Cache') === 'true',
                 context: {
@@ -201,9 +202,17 @@ export default {
                 events: [],
             })
 
+            const replicationPlugin = new ReplicationPlugin({
+                replicas: [],
+                authToken: '',
+                // tables: ['users', 'orders'],
+            })
+
             cdcPlugin.onEvent(async ({ action, schema, table, data }) => {
                 // Include change data capture code here
             }, ctx)
+
+            replicationPlugin.onEvent(ctx)
 
             cronPlugin.onEvent(async ({ name, cron_tab, payload }) => {
                 // Include cron event code here
@@ -226,6 +235,7 @@ export default {
                 cronPlugin,
                 new StatsPlugin(),
                 interfacePlugin,
+                replicationPlugin,
             ] satisfies StarbasePlugin[]
 
             const starbase = new StarbaseDB({


### PR DESCRIPTION
/claim #72

Closes #72

### Summary

This PR introduces a replication plugin that propagates write queries (`INSERT`, `UPDATE`, `DELETE`, `REPLACE`) to peer StarbaseDB instances using the existing plugin system.

Replication is implemented using the `afterQuery` hook and `ExecutionContext.waitUntil`, ensuring zero impact on primary query latency.

---

### Design Approach

Rather than introducing polling or scheduled sync, replication is implemented via query interception. This aligns with:

* StarbaseDB’s plugin architecture
* Cloudflare Worker runtime constraints (no persistent timers)
* Existing patterns established by the CDC plugin

---

### Key Properties

* **Non-blocking:** replication runs in `waitUntil` (no added latency)
* **Fail-safe:** replication errors never affect primary query execution
* **Parallel fanout:** uses `Promise.allSettled` to isolate replica failures
* **Selective replication:** optional table-level filtering
* **Minimal surface area:** no new APIs, no changes to existing flows

---

### Differentiation from CDC Plugin

While the CDC plugin focuses on emitting change events for observability, this plugin focuses on **write propagation across instances**, enabling simple replication setups.

---

### Usage

```ts
const replicationPlugin = new ReplicationPlugin({
  replicas: ['https://replica.example.workers.dev'],
  authToken: 'your-token',
})

replicationPlugin.onEvent(ctx)
```

---

### Notes

* Replication is intentionally event-driven (not polling-based)
* Replica instances must share compatible schema
* Avoid pointing replicas back to the primary to prevent loops

---

### Why this approach

This implementation prioritizes:

* architectural alignment
* minimal integration risk
* production safety
