### PR TITLE
Fix schema-aware RLS policy coverage

### DIFF
--- a/src/rls/index.test.ts
+++ b/src/rls/index.test.ts
@@ -17,6 +17,11 @@ const mockConfig: StarbaseDBConfiguration = {
     features: { allowlist: true, rls: true, rest: true },
 }
 
+beforeEach(() => {
+    mockConfig.role = 'client'
+    mockDataSource.context.sub = 'user123'
+})
+
 describe('loadPolicies - Policy Fetching and Parsing', () => {
     it('should load and parse policies correctly', async () => {
         vi.mocked(mockDataSource.rpc.executeQuery).mockResolvedValue([
@@ -94,10 +99,21 @@ describe('applyRLS - Query Modification', () => {
             config: mockConfig,
         })
 
-        console.log('Final SQL:', modifiedSql)
-        expect(modifiedSql).toContain("WHERE `user_id` = 'user123'")
+        expect(modifiedSql).toContain("WHERE (`users`.`user_id` = 'user123')")
     })
     it('should modify DELETE queries by adding policy-based WHERE clause', async () => {
+        vi.mocked(mockDataSource.rpc.executeQuery).mockResolvedValue([
+            {
+                actions: 'DELETE',
+                schema: 'public',
+                table: 'users',
+                column: 'user_id',
+                value: 'context.id()',
+                value_type: 'string',
+                operator: '=',
+            },
+        ])
+
         const sql = "DELETE FROM users WHERE name = 'Alice'"
         const modifiedSql = await applyRLS({
             sql,
@@ -106,10 +122,23 @@ describe('applyRLS - Query Modification', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("WHERE `name` = 'Alice'")
+        expect(modifiedSql).toContain("`name` = 'Alice'")
+        expect(modifiedSql).toContain("`users`.`user_id` = 'user123'")
     })
 
     it('should modify UPDATE queries with additional WHERE clause', async () => {
+        vi.mocked(mockDataSource.rpc.executeQuery).mockResolvedValue([
+            {
+                actions: 'UPDATE',
+                schema: 'public',
+                table: 'users',
+                column: 'user_id',
+                value: 'context.id()',
+                value_type: 'string',
+                operator: '=',
+            },
+        ])
+
         const sql = "UPDATE users SET name = 'Bob' WHERE age = 25"
         const modifiedSql = await applyRLS({
             sql,
@@ -118,10 +147,24 @@ describe('applyRLS - Query Modification', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("`name` = 'Bob' WHERE `age` = 25")
+        expect(modifiedSql).toContain("`name` = 'Bob'")
+        expect(modifiedSql).toContain('`age` = 25')
+        expect(modifiedSql).toContain("`users`.`user_id` = 'user123'")
     })
 
     it('should modify INSERT queries to enforce column values', async () => {
+        vi.mocked(mockDataSource.rpc.executeQuery).mockResolvedValue([
+            {
+                actions: 'INSERT',
+                schema: 'public',
+                table: 'users',
+                column: 'user_id',
+                value: 'context.id()',
+                value_type: 'string',
+                operator: '=',
+            },
+        ])
+
         const sql = "INSERT INTO users (user_id, name) VALUES (1, 'Alice')"
         const modifiedSql = await applyRLS({
             sql,
@@ -130,7 +173,34 @@ describe('applyRLS - Query Modification', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("VALUES (1,'Alice')")
+        expect(modifiedSql).toContain("VALUES ('user123','Alice')")
+    })
+
+    it('should reject restricted table actions without an explicit policy', async () => {
+        const sql = "UPDATE users SET name = 'Bob' WHERE age = 25"
+
+        await expect(
+            applyRLS({
+                sql,
+                isEnabled: true,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
+        ).rejects.toThrow(
+            'Unauthorized access: No matching rules for UPDATE on restricted table users'
+        )
+    })
+
+    it('should not apply policies to a different schema-qualified table', async () => {
+        const sql = 'SELECT * FROM private.users'
+        const modifiedSql = await applyRLS({
+            sql,
+            isEnabled: true,
+            dataSource: mockDataSource,
+            config: mockConfig,
+        })
+
+        expect(modifiedSql).not.toContain('user_id')
     })
 })
 
@@ -200,15 +270,15 @@ describe('applyRLS - Multi-Table Queries', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("WHERE `users.user_id` = 'user123'")
-        expect(modifiedSql).toContain("AND `orders.user_id` = 'user123'")
+        expect(modifiedSql).toContain("`users`.`user_id` = 'user123'")
+        expect(modifiedSql).toContain("`orders`.`user_id` = 'user123'")
     })
 
-    it('should apply RLS policies to multiple tables in a JOIN', async () => {
+    it('should apply RLS policies to aliased tables in a JOIN', async () => {
         const sql = `
-            SELECT users.name, orders.total 
-            FROM users 
-            JOIN orders ON users.id = orders.user_id
+            SELECT u.name, o.total
+            FROM users AS u
+            JOIN orders AS o ON u.id = o.user_id
         `
 
         const modifiedSql = await applyRLS({
@@ -218,8 +288,8 @@ describe('applyRLS - Multi-Table Queries', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("WHERE (users.user_id = 'user123')")
-        expect(modifiedSql).toContain("AND (orders.user_id = 'user123')")
+        expect(modifiedSql).toContain("`u`.`user_id` = 'user123'")
+        expect(modifiedSql).toContain("`o`.`user_id` = 'user123'")
     })
 
     it('should apply RLS policies to subqueries inside FROM clause', async () => {
@@ -236,6 +306,6 @@ describe('applyRLS - Multi-Table Queries', () => {
             config: mockConfig,
         })
 
-        expect(modifiedSql).toContain("WHERE `users.user_id` = 'user123'")
+        expect(modifiedSql).toContain("`users`.`user_id` = 'user123'")
     })
 })

--- a/src/rls/index.ts
+++ b/src/rls/index.ts
@@ -47,6 +47,78 @@ function normalizeIdentifier(name: string): string {
     return name
 }
 
+function getUnqualifiedTableName(name: string): string {
+    const normalized = normalizeIdentifier(name)
+    return normalized.includes('.') ? normalized.split('.').pop()! : normalized
+}
+
+function getFullTableName(tableRef: any): string | undefined {
+    const tableName = normalizeIdentifier(tableRef?.table)
+    if (!tableName) return undefined
+
+    const schemaName = normalizeIdentifier(tableRef?.db)
+    return schemaName ? `${schemaName}.${tableName}` : tableName
+}
+
+function tableNamesMatch(policyTable: string, queryTable: string): boolean {
+    const normalizedPolicyTable = normalizeIdentifier(policyTable)
+    const normalizedQueryTable = normalizeIdentifier(queryTable)
+    const policyHasSchema = normalizedPolicyTable.includes('.')
+    const queryHasSchema = normalizedQueryTable.includes('.')
+
+    return (
+        normalizedPolicyTable === normalizedQueryTable ||
+        ((!policyHasSchema || !queryHasSchema) &&
+            getUnqualifiedTableName(normalizedPolicyTable) ===
+                getUnqualifiedTableName(normalizedQueryTable))
+    )
+}
+
+function getAstTableRefs(ast: any, statementType: string) {
+    const tableRefs =
+        statementType === 'INSERT' || statementType === 'UPDATE'
+            ? ast.table
+            : ast.from
+
+    return (tableRefs ?? [])
+        .map((tableRef: any) => {
+            const tableName = getFullTableName(tableRef)
+            if (!tableName) return null
+
+            return {
+                name: tableName,
+                conditionTable: tableRef.as ?? tableRef.table,
+            }
+        })
+        .filter(Boolean) as Array<{
+        name: string
+        conditionTable: string | null
+    }>
+}
+
+function getConditionForTable(
+    condition: Policy['condition'],
+    tableName: string | null
+) {
+    return {
+        ...condition,
+        left: {
+            ...condition.left,
+            table: tableName,
+        },
+        right: {
+            ...condition.right,
+        },
+    }
+}
+
+function getNestedSelect(expr: any) {
+    if (!expr) return undefined
+    if (expr.type === 'select') return expr
+    if (expr.ast?.type === 'select') return expr.ast
+    return undefined
+}
+
 export async function loadPolicies(dataSource: DataSource): Promise<Policy[]> {
     try {
         const statement =
@@ -232,57 +304,28 @@ function applyRLSToAst(ast: any): void {
         traverseWhere(ast.where)
     }
 
-    const tablesWithRules: Record<string, string[]> = {}
-    policies.forEach((policy) => {
-        const tbl = normalizeIdentifier(policy.condition.left.table)
-        if (!tablesWithRules[tbl]) {
-            tablesWithRules[tbl] = []
-        }
-        tablesWithRules[tbl].push(policy.action)
-    })
-
     const statementType = ast.type?.toUpperCase()
     if (!['SELECT', 'UPDATE', 'DELETE', 'INSERT'].includes(statementType)) {
         return
     }
 
-    let tables: string[] = []
-    if (statementType === 'INSERT') {
-        let tableName = normalizeIdentifier(ast.table[0].table)
-        if (tableName.includes('.')) {
-            tableName = tableName.split('.')[1]
-        }
-        tables = [tableName]
-    } else if (statementType === 'UPDATE') {
-        tables = ast.table.map((tableRef: any) => {
-            let tableName = normalizeIdentifier(tableRef.table)
-            if (tableName.includes('.')) {
-                tableName = tableName.split('.')[1]
-            }
-            return tableName
-        })
-    } else {
-        // SELECT or DELETE
-        tables =
-            ast.from?.map((fromTable: any) => {
-                let tableName = normalizeIdentifier(fromTable.table)
-                if (tableName.includes('.')) {
-                    tableName = tableName.split('.')[1]
-                }
-                return tableName
-            }) || []
-    }
+    const tableRefs = getAstTableRefs(ast, statementType)
 
-    const restrictedTables = Object.keys(tablesWithRules)
+    for (const tableRef of tableRefs) {
+        const allowedActions = policies
+            .filter((policy) =>
+                tableNamesMatch(policy.condition.left.table, tableRef.name)
+            )
+            .map((policy) => policy.action)
 
-    for (const table of tables) {
-        if (restrictedTables.includes(table)) {
-            const allowedActions = tablesWithRules[table]
-            if (!allowedActions.includes(statementType)) {
-                throw new Error(
-                    `Unauthorized access: No matching rules for ${statementType} on restricted table ${table}`
-                )
-            }
+        if (
+            allowedActions.length > 0 &&
+            !allowedActions.includes(statementType) &&
+            !allowedActions.includes('*')
+        ) {
+            throw new Error(
+                `Unauthorized access: No matching rules for ${statementType} on restricted table ${tableRef.name}`
+            )
         }
     }
 
@@ -292,9 +335,16 @@ function applyRLSToAst(ast: any): void {
         )
         .forEach(({ action, condition }) => {
             const targetTable = normalizeIdentifier(condition.left.table)
-            const isTargetTable = tables.includes(targetTable)
+            const tableRef = tableRefs.find((table) =>
+                tableNamesMatch(targetTable, table.name)
+            )
 
-            if (!isTargetTable) return
+            if (!tableRef) return
+
+            const tableCondition = getConditionForTable(
+                condition,
+                tableRef.conditionTable
+            )
 
             if (action !== 'INSERT') {
                 // Add condition to WHERE with parentheses
@@ -308,13 +358,13 @@ function applyRLSToAst(ast: any): void {
                             parentheses: true,
                         },
                         right: {
-                            ...condition,
+                            ...tableCondition,
                             parentheses: true,
                         },
                     }
                 } else {
                     ast.where = {
-                        ...condition,
+                        ...tableCondition,
                         parentheses: true,
                     }
                 }
@@ -349,8 +399,9 @@ function applyRLSToAst(ast: any): void {
         })
 
     ast.from?.forEach((fromItem: any) => {
-        if (fromItem.expr && fromItem.expr.type === 'select') {
-            applyRLSToAst(fromItem.expr)
+        const nestedSelect = getNestedSelect(fromItem.expr)
+        if (nestedSelect) {
+            applyRLSToAst(nestedSelect)
         }
 
         // Handle both single join and array of joins
@@ -359,8 +410,9 @@ function applyRLSToAst(ast: any): void {
                 ? fromItem.join
                 : [fromItem]
             joins.forEach((joinItem: any) => {
-                if (joinItem.expr && joinItem.expr.type === 'select') {
-                    applyRLSToAst(joinItem.expr)
+                const joinSelect = getNestedSelect(joinItem.expr)
+                if (joinSelect) {
+                    applyRLSToAst(joinSelect)
                 }
             })
         }
@@ -371,8 +423,9 @@ function applyRLSToAst(ast: any): void {
     }
 
     ast.columns?.forEach((column: any) => {
-        if (column.expr && column.expr.type === 'select') {
-            applyRLSToAst(column.expr)
+        const nestedSelect = getNestedSelect(column.expr)
+        if (nestedSelect) {
+            applyRLSToAst(nestedSelect)
         }
     })
 }
@@ -381,6 +434,9 @@ function traverseWhere(node: any): void {
     if (!node) return
     if (node.type === 'select') {
         applyRLSToAst(node)
+    }
+    if (node.ast?.type === 'select') {
+        applyRLSToAst(node.ast)
     }
     if (node.left) traverseWhere(node.left)
     if (node.right) traverseWhere(node.right)


### PR DESCRIPTION
/claim #71

## Summary
- Match schema-qualified RLS policy tables such as `public.users` against unqualified SQL tables like `users` without leaking across differently qualified schemas.
- Apply injected RLS predicates through table aliases and nested `FROM (...)` SELECT subqueries.
- Tighten RLS regression coverage for SELECT, DELETE, UPDATE, INSERT, explicit deny behavior, alias handling, subqueries, and schema mismatch handling.

## Proof / Verification
This is backend RLS logic, so the demo is command-based rather than UI/video. The behavior is covered by focused regression tests and the full suite.

```text
$ npx vitest src/rls/index.test.ts --run
✓ src/rls/index.test.ts (13 tests)
Test Files  1 passed (1)
Tests       13 passed (13)
```

```text
$ npx vitest --run
Test Files  19 passed (19)
Tests       157 passed (157)
```

```text
$ npx prettier --check src/rls/index.ts src/rls/index.test.ts
All matched files use Prettier code style!
```

I also checked coverage locally: all tests pass under coverage collection, and the touched RLS module is covered at 88.31% statements / 89.44% lines / 74.41% branches. The repo-wide branch threshold remains below the configured global threshold before/after this PR, so the focused and full test-suite proof above are the reliable verification signals for this backend-only change.
