### PR TITLE
test: add CSV import route coverage

### DIFF
--- a/src/import/csv.test.ts
+++ b/src/import/csv.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { executeOperation } from '../export'
+import type { StarbaseDBConfiguration } from '../handler'
+import type { DataSource } from '../types'
+import { importTableFromCsvRoute } from './csv'
+
+vi.mock('../export', () => ({
+    executeOperation: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+    createResponse: vi.fn(
+        (data, message, status) =>
+            new Response(JSON.stringify({ result: data, error: message }), {
+                status,
+                headers: { 'Content-Type': 'application/json' },
+            })
+    ),
+}))
+
+let mockDataSource: DataSource
+let mockConfig: StarbaseDBConfiguration
+
+beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockDataSource = {
+        source: 'external',
+        external: { dialect: 'sqlite' },
+        rpc: { executeQuery: vi.fn() },
+    } as any
+
+    mockConfig = {
+        outerbaseApiKey: 'mock-api-key',
+        role: 'admin',
+        features: { allowlist: true, rls: true, rest: true },
+    }
+})
+
+describe('CSV Import Module', () => {
+    it('returns 400 when the request body is empty', async () => {
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/csv' },
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(400)
+        const jsonResponse = (await response.json()) as { error?: string }
+        expect(jsonResponse.error).toBe('Request body is empty')
+        expect(executeOperation).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for unsupported content types', async () => {
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain' },
+            body: 'id,name\n1,Alice',
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(400)
+        const jsonResponse = (await response.json()) as { error?: string }
+        expect(jsonResponse.error).toBe('Unsupported Content-Type')
+        expect(executeOperation).not.toHaveBeenCalled()
+    })
+
+    it('imports raw text/csv rows', async () => {
+        vi.mocked(executeOperation).mockResolvedValue([])
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/csv' },
+            body: 'id,name\n1,Alice\n2,Bob\n',
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(200)
+        expect(executeOperation).toHaveBeenCalledTimes(2)
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            1,
+            [
+                {
+                    sql: 'INSERT INTO users (id, name) VALUES (?, ?)',
+                    params: ['1', 'Alice'],
+                },
+            ],
+            mockDataSource,
+            mockConfig
+        )
+
+        const jsonResponse = (await response.json()) as {
+            result: { message: string; failedStatements: unknown[] }
+        }
+        expect(jsonResponse.result.message).toBe(
+            'Imported 2 out of 2 records successfully. 0 records failed.'
+        )
+        expect(jsonResponse.result.failedStatements).toEqual([])
+    })
+
+    it('applies column mapping from JSON-wrapped CSV data', async () => {
+        vi.mocked(executeOperation).mockResolvedValue([])
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                data: 'user_id,full_name\n1,Alice',
+                columnMapping: {
+                    user_id: 'id',
+                    full_name: 'name',
+                },
+            }),
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(200)
+        expect(executeOperation).toHaveBeenCalledWith(
+            [
+                {
+                    sql: 'INSERT INTO users (id, name) VALUES (?, ?)',
+                    params: ['1', 'Alice'],
+                },
+            ],
+            mockDataSource,
+            mockConfig
+        )
+    })
+
+    it('returns 400 when multipart upload has no file', async () => {
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            body: new FormData(),
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(400)
+        const jsonResponse = (await response.json()) as { error?: string }
+        expect(jsonResponse.error).toBe('No file uploaded')
+        expect(executeOperation).not.toHaveBeenCalled()
+    })
+
+    it('reports failed inserts without hiding successful rows', async () => {
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([])
+            .mockRejectedValueOnce(new Error('Database Error'))
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/csv' },
+            body: 'id,name\n1,Alice\n2,Bob',
+        })
+
+        const response = await importTableFromCsvRoute(
+            'users',
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(200)
+        const jsonResponse = (await response.json()) as {
+            result: {
+                message: string
+                failedStatements: Array<{ statement: string; error: string }>
+            }
+        }
+        expect(jsonResponse.result.message).toBe(
+            'Imported 1 out of 2 records successfully. 1 records failed.'
+        )
+        expect(jsonResponse.result.failedStatements).toEqual([
+            {
+                statement: 'INSERT INTO users (id, name) VALUES (?, ?)',
+                error: 'Database Error',
+            },
+        ])
+    })
+})


### PR DESCRIPTION
## Summary
- Improves the test coverage requested in #71.
- Adds focused Vitest coverage for the CSV import route without changing runtime behavior.

## Changes
- Cover empty request bodies and unsupported content types.
- Cover raw `text/csv` imports and JSON-wrapped CSV imports with column mapping.
- Cover multipart uploads with no file.
- Cover partial insert failures while preserving successful rows.

## Testing
- `bun x vitest run src/import/csv.test.ts`
- Result: passed, 6 passed / 0 failed
- `bun x prettier --check src/import/csv.test.ts`
- Result: passed
- `git diff --check`
- Result: passed
- `bun x vitest run`
- Result: partial, new CSV tests passed; existing `src/rls/index.test.ts` has 4 unrelated failures on current main in this local environment.
- `bun x tsc --noEmit`
- Result: failed on pre-existing project type errors outside this change, including Cloudflare/WebSocket test types and existing cache test mocks.

## Notes
- No authentication, payment, database, deployment, or security-sensitive configuration changes were made.
- No secrets, credentials, production data, or security-sensitive information were accessed.

## Algora
/claim #71