### PR TITLE
test: cover durable object request and alarm paths

### DIFF
--- a/src/do.test.ts
+++ b/src/do.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { StarbaseDBDurableObject } from './do'
 
 vi.mock('cloudflare:workers', () => {
     return {
-        DurableObject: class MockDurableObject {},
+        DurableObject: class MockDurableObject {
+            ctx: DurableObjectState
+            env: Env
+
+            constructor(ctx: DurableObjectState, env: Env) {
+                this.ctx = ctx
+                this.env = env
+            }
+        },
     }
 })
 
@@ -58,22 +66,28 @@ global.Response = class {
     }
 }
 
+const createMockCursor = () => ({
+    columnNames: ['id', 'name'],
+    raw: vi.fn().mockReturnValue([
+        [1, 'Alice'],
+        [2, 'Bob'],
+    ]),
+    toArray: vi.fn().mockReturnValue([
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+    ]),
+    rowsRead: 2,
+    rowsWritten: 1,
+})
+
 const mockStorage = {
     sql: {
-        exec: vi.fn().mockReturnValue({
-            columnNames: ['id', 'name'],
-            raw: vi.fn().mockReturnValue([
-                [1, 'Alice'],
-                [2, 'Bob'],
-            ]),
-            toArray: vi.fn().mockReturnValue([
-                { id: 1, name: 'Alice' },
-                { id: 2, name: 'Bob' },
-            ]),
-            rowsRead: 2,
-            rowsWritten: 1,
-        }),
+        databaseSize: 4096,
+        exec: vi.fn(() => createMockCursor()),
     },
+    getAlarm: vi.fn(),
+    setAlarm: vi.fn(),
+    deleteAlarm: vi.fn(),
 }
 
 const mockDurableObjectState = {
@@ -81,19 +95,48 @@ const mockDurableObjectState = {
     getTags: vi.fn().mockReturnValue(['session-123']),
 } as any
 
-const mockEnv = {} as any
+const mockEnv = { CLIENT_AUTHORIZATION_TOKEN: 'client-token' } as any
 
 let instance: StarbaseDBDurableObject
 
 beforeEach(() => {
+    mockStorage.sql.exec.mockImplementation(() => createMockCursor())
+    mockStorage.getAlarm.mockResolvedValue(null)
+    mockStorage.setAlarm.mockResolvedValue(undefined)
+    mockStorage.deleteAlarm.mockResolvedValue(undefined)
+    mockDurableObjectState.getTags.mockReturnValue(['session-123'])
+
     instance = new StarbaseDBDurableObject(mockDurableObjectState, mockEnv)
-    vi.clearAllMocks()
+
+    mockStorage.sql.exec.mockClear()
+    mockStorage.getAlarm.mockClear()
+    mockStorage.setAlarm.mockClear()
+    mockStorage.deleteAlarm.mockClear()
+    mockDurableObjectState.getTags.mockClear()
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
 })
 
 describe('StarbaseDBDurableObject Tests', () => {
     it('should initialize SQL storage', () => {
         expect(instance.sql).toBeDefined()
         expect(instance.storage).toBeDefined()
+    })
+
+    it('should install default temporary tables on construction', () => {
+        new StarbaseDBDurableObject(mockDurableObjectState, mockEnv)
+
+        const schemaStatements = mockStorage.sql.exec.mock.calls.map((call) =>
+            String((call as unknown[])[0])
+        )
+        expect(schemaStatements).toHaveLength(4)
+        expect(schemaStatements[0]).toContain('tmp_cache')
+        expect(schemaStatements[1]).toContain('tmp_allowlist_queries')
+        expect(schemaStatements[2]).toContain('tmp_allowlist_rejections')
+        expect(schemaStatements[3]).toContain('tmp_rls_policies')
     })
 
     it('should execute a query and return results', async () => {
@@ -132,17 +175,389 @@ describe('StarbaseDBDurableObject Tests', () => {
         expect(response.status).toBe(400)
     })
 
+    it('should expose bound durable object helpers from init()', async () => {
+        mockStorage.getAlarm.mockResolvedValueOnce(12345)
+
+        const helpers = instance.init()
+        const alarm = await helpers.getAlarm()
+        await helpers.deleteAlarm()
+        const queryResult = await helpers.executeQuery({
+            sql: 'SELECT * FROM users',
+        })
+
+        expect(alarm).toBe(12345)
+        expect(mockStorage.getAlarm).toHaveBeenCalled()
+        expect(mockStorage.deleteAlarm).toHaveBeenCalled()
+        expect(queryResult).toEqual([
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' },
+        ])
+    })
+
+    it('should expose statistics from init()', async () => {
+        const helpers = instance.init()
+        vi.spyOn(instance, 'executeQuery').mockResolvedValueOnce([
+            { count: 7 },
+        ] as any)
+        instance.connections.set(
+            'active-session',
+            new global.WebSocket('ws://localhost') as any
+        )
+
+        const statistics = await helpers.getStatistics()
+
+        expect(instance.executeQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sql: expect.stringContaining('tmp_query_log'),
+                isRaw: false,
+            })
+        )
+        expect(statistics).toEqual({
+            databaseSize: 4096,
+            activeConnections: 1,
+            recentQueries: 7,
+        })
+    })
+
+    it('should clamp scheduled alarms to at least one second in the future', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-05-12T12:00:00Z'))
+
+        await instance.setAlarm(Date.now() + 100, {
+            allowConcurrency: true,
+        } as any)
+
+        expect(mockStorage.setAlarm).toHaveBeenCalledWith(Date.now() + 1000, {
+            allowConcurrency: true,
+        })
+    })
+
+    it('should log and rethrow alarm scheduling failures', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const failure = new Error('storage failed')
+        mockStorage.setAlarm.mockRejectedValueOnce(failure)
+
+        await expect(instance.setAlarm(Date.now() + 1000)).rejects.toThrow(
+            'storage failed'
+        )
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error setting alarm: ',
+            failure
+        )
+    })
+
+    it('should return a raw query response with metadata when requested', async () => {
+        const result = await instance.executeQuery({
+            sql: 'SELECT * FROM users WHERE id = ?',
+            params: [1],
+            isRaw: true,
+        })
+
+        expect(mockStorage.sql.exec).toHaveBeenCalledWith(
+            'SELECT * FROM users WHERE id = ?',
+            1
+        )
+        expect(result).toEqual({
+            columns: ['id', 'name'],
+            rows: [
+                [1, 'Alice'],
+                [2, 'Bob'],
+            ],
+            meta: {
+                rows_read: 2,
+                rows_written: 1,
+            },
+        })
+    })
+
+    it('should rethrow transaction errors after logging them', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const failure = new Error('second query failed')
+
+        vi.spyOn(instance, 'executeQuery')
+            .mockResolvedValueOnce([{ ok: true }] as any)
+            .mockRejectedValueOnce(failure)
+
+        await expect(
+            instance.executeTransaction(
+                [{ sql: 'SELECT 1' }, { sql: 'SELECT broken' }],
+                false
+            )
+        ).rejects.toThrow('second query failed')
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Transaction Execution Error:',
+            failure
+        )
+    })
+
+    it('should reject socket requests that are missing a websocket upgrade', async () => {
+        const response = await instance.fetch(
+            new Request('https://example.com/socket')
+        )
+
+        expect(response.status).toBe(400)
+    })
+
+    it('should create websocket sessions through the fetch upgrade path', async () => {
+        const response = await instance.fetch(
+            new Request('https://example.com/socket?sessionId=session-abc', {
+                headers: { upgrade: 'websocket' },
+            })
+        )
+
+        expect(response.status).toBe(101)
+        expect(instance.connections.has('session-abc')).toBe(true)
+    })
+
+    it('should dispatch websocket message handlers and clean up errored sockets', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const response = await instance.clientConnected('session-error')
+        const server = instance.connections.get('session-error') as any
+        const messageHandler = server.addEventListener.mock.calls.find(
+            ([event]: [string]) => event === 'message'
+        )?.[1]
+        const errorHandler = server.addEventListener.mock.calls.find(
+            ([event]: [string]) => event === 'error'
+        )?.[1]
+        const webSocketMessageSpy = vi
+            .spyOn(instance, 'webSocketMessage')
+            .mockResolvedValueOnce(undefined)
+        const failure = new Error('closed')
+
+        await messageHandler({ data: '{"action":"query"}' })
+        errorHandler(failure)
+
+        expect(response.status).toBe(101)
+        expect(webSocketMessageSpy).toHaveBeenCalledWith(
+            server,
+            '{"action":"query"}'
+        )
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'WebSocket error for session-error:',
+            failure
+        )
+        expect(instance.connections.has('session-error')).toBe(false)
+    })
+
+    it('should broadcast messages only to the requested session', async () => {
+        const target = new global.WebSocket('ws://localhost') as any
+        const other = new global.WebSocket('ws://localhost') as any
+        instance.connections.set('target-session', target)
+        instance.connections.set('other-session', other)
+
+        const response = await instance.fetch(
+            new Request(
+                'https://example.com/socket/broadcast?sessionId=target-session',
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ event: 'refresh' }),
+                }
+            )
+        )
+
+        expect(response.status).toBe(200)
+        expect(target.send).toHaveBeenCalledWith(
+            JSON.stringify({ event: 'refresh' })
+        )
+        expect(other.send).not.toHaveBeenCalled()
+    })
+
+    it('should remove failed websocket connections during broadcast', async () => {
+        const failedSocket = new global.WebSocket('ws://localhost') as any
+        failedSocket.send = vi.fn(() => {
+            throw new Error('closed')
+        })
+        instance.connections.set('dead-session', failedSocket)
+
+        await instance.fetch(
+            new Request('https://example.com/socket/broadcast', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ event: 'refresh' }),
+            })
+        )
+
+        expect(instance.connections.has('dead-session')).toBe(false)
+    })
+
+    it('should execute websocket query messages and send the results', async () => {
+        const ws = new global.WebSocket('ws://localhost') as any
+        vi.spyOn(instance, 'executeTransaction').mockResolvedValueOnce([
+            [{ id: 1 }],
+        ])
+
+        await instance.webSocketMessage(
+            ws,
+            JSON.stringify({
+                action: 'query',
+                sql: 'SELECT * FROM users WHERE id = ?',
+                params: [1],
+            })
+        )
+
+        expect(instance.executeTransaction).toHaveBeenCalledWith(
+            [{ sql: 'SELECT * FROM users WHERE id = ?', params: [1] }],
+            false
+        )
+        expect(ws.send).toHaveBeenCalledWith(JSON.stringify([[{ id: 1 }]]))
+    })
+
+    it('should close websocket connections and remove tagged sessions', async () => {
+        const ws = new global.WebSocket('ws://localhost') as any
+        instance.connections.set('session-123', ws)
+
+        await instance.webSocketClose(ws, 1000, 'done', true)
+
+        expect(ws.close).toHaveBeenCalledWith(
+            1000,
+            'StarbaseDB is closing WebSocket connection'
+        )
+        expect(instance.connections.has('session-123')).toBe(false)
+    })
+
+    it('should skip cron callbacks when no active tasks exist', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        vi.spyOn(instance, 'executeQuery').mockResolvedValueOnce([])
+
+        await instance.alarm()
+
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('should invoke cron callbacks with client auth when active tasks exist', async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(new Response(null, { status: 200 }) as any)
+        vi.spyOn(instance, 'executeQuery').mockResolvedValueOnce([
+            { callback_host: 'https://cron.example.com' },
+        ] as any)
+
+        await instance.alarm()
+
+        expect(fetchSpy).toHaveBeenCalledWith(
+            'https://cron.example.com/cron/callback',
+            expect.objectContaining({
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer client-token',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify([
+                    { callback_host: 'https://cron.example.com' },
+                ]),
+            })
+        )
+    })
+
+    it('should reschedule cron alarms when callbacks fail', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+            new Error('network failed')
+        )
+        vi.spyOn(instance, 'executeQuery').mockResolvedValueOnce([
+            { callback_host: 'https://cron.example.com' },
+        ] as any)
+        const setAlarmSpy = vi
+            .spyOn(instance, 'setAlarm')
+            .mockResolvedValueOnce(undefined)
+
+        await instance.alarm()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to call the alarm/cron callback:',
+            expect.any(Error)
+        )
+        expect(setAlarmSpy).toHaveBeenCalledWith(expect.any(Number))
+    })
+
+    it('should log recovery alarm failures after callback errors', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const retryFailure = new Error('retry failed')
+        vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+            new Error('network failed')
+        )
+        vi.spyOn(instance, 'executeQuery').mockResolvedValueOnce([
+            { callback_host: 'https://cron.example.com' },
+        ] as any)
+        vi.spyOn(instance, 'setAlarm').mockRejectedValueOnce(retryFailure)
+
+        await instance.alarm()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to set recovery alarm:',
+            retryFailure
+        )
+    })
+
+    it('should reschedule alarms when task lookup fails', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const failure = new Error('query failed')
+        vi.spyOn(instance, 'executeQuery').mockRejectedValueOnce(failure)
+        const setAlarmSpy = vi
+            .spyOn(instance, 'setAlarm')
+            .mockResolvedValueOnce(undefined)
+
+        await instance.alarm()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'There was an error processing an alarm: ',
+            failure
+        )
+        expect(setAlarmSpy).toHaveBeenCalledWith(expect.any(Number))
+    })
+
+    it('should log recovery alarm failures when task lookup fails', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const failure = new Error('query failed')
+        const retryFailure = new Error('retry failed')
+        vi.spyOn(instance, 'executeQuery').mockRejectedValueOnce(failure)
+        vi.spyOn(instance, 'setAlarm').mockRejectedValueOnce(retryFailure)
+
+        await instance.alarm()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'There was an error processing an alarm: ',
+            failure
+        )
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to set recovery alarm:',
+            retryFailure
+        )
+    })
+
     it('should handle errors in executeQuery', async () => {
         const consoleErrorSpy = vi
             .spyOn(console, 'error')
-            .mockImplementation(() => {}) // ✅ Suppress error logs
+            .mockImplementation(() => {})
+
+        const failure = new Error('Query failed')
 
         mockStorage.sql.exec.mockImplementationOnce(() => {
-            throw new Error('Query failed')
+            throw failure
         })
 
         await expect(
             instance.executeQuery({ sql: 'INVALID QUERY' })
         ).rejects.toThrow('Query failed')
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'SQL Execution Error:',
+            failure
+        )
     })
 })


### PR DESCRIPTION
/claim #71

## Summary
- Expands the Durable Object test harness so `src/do.test.ts` can exercise storage alarms, `ctx.getTags`, environment auth tokens, and fresh SQL cursors per test.
- Adds focused coverage for default temporary table setup, `init()` helper bindings, statistics, alarm scheduling and recovery errors, raw query metadata, transaction error propagation, socket upgrade routing, websocket message/error/close cleanup, broadcast filtering, and cron callback auth/retry behavior.
- Test-only change; no production behavior is changed.

## Verification
- `\.\node_modules\.bin\prettier.cmd --check src/do.test.ts` passed.
- `git diff --check -- src/do.test.ts` passed.
- `\.\node_modules\.bin\vitest.cmd run src/do.test.ts` passed: 26 tests.
- `\.\node_modules\.bin\vitest.cmd run src/do.test.ts --coverage --coverage.reporter=text` passed the focused test file; the command exits 1 only because global coverage thresholds are evaluated while a single test file is selected. The focused report shows `src/do.ts` at 100% statements, 79.41% branches, 100% functions, and 100% lines.
- `\.\node_modules\.bin\vitest.cmd run` still has the existing unrelated RLS baseline failures in `src/rls/index.test.ts`:
  - `applyRLS - Query Modification > should modify SELECT queries with WHERE conditions`
  - `applyRLS - Multi-Table Queries > should apply RLS policies to tables in JOIN conditions`
  - `applyRLS - Multi-Table Queries > should apply RLS policies to multiple tables in a JOIN`
  - `applyRLS - Multi-Table Queries > should apply RLS policies to subqueries inside FROM clause`

Advertised bounty: $250 via Algora on #71.