### PR TITLE
test: cover plugin registry beforeQuery chaining

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -92,6 +92,57 @@ describe('StarbasePlugin', () => {
 
         expect(result.sql).toBe('[B] [A] SELECT * FROM users')
     })
+
+    it('should call each beforeQuery hook once with the previous hook output', async () => {
+        const firstPlugin = new TestPlugin('FirstPlugin')
+        const secondPlugin = new TestPlugin('SecondPlugin')
+
+        const firstBeforeQuery = vi
+            .spyOn(firstPlugin, 'beforeQuery')
+            .mockResolvedValue({
+                sql: 'SELECT * FROM users WHERE active = ?',
+                params: [1],
+            })
+        const secondBeforeQuery = vi
+            .spyOn(secondPlugin, 'beforeQuery')
+            .mockResolvedValue({
+                sql: 'SELECT * FROM users WHERE active = ? LIMIT ?',
+                params: [1, 10],
+            })
+
+        const dataSource = { source: 'internal' } as DataSource
+        const config = { role: 'admin' } as StarbaseDBConfiguration
+        const registry = new StarbasePluginRegistry({
+            app: mockApp,
+            plugins: [firstPlugin, secondPlugin],
+        })
+
+        const result = await registry.beforeQuery({
+            sql: 'SELECT * FROM users',
+            params: [],
+            dataSource,
+            config,
+        })
+
+        expect(firstBeforeQuery).toHaveBeenCalledTimes(1)
+        expect(firstBeforeQuery).toHaveBeenCalledWith({
+            sql: 'SELECT * FROM users',
+            params: [],
+            dataSource,
+            config,
+        })
+        expect(secondBeforeQuery).toHaveBeenCalledTimes(1)
+        expect(secondBeforeQuery).toHaveBeenCalledWith({
+            sql: 'SELECT * FROM users WHERE active = ?',
+            params: [1],
+            dataSource,
+            config,
+        })
+        expect(result).toEqual({
+            sql: 'SELECT * FROM users WHERE active = ? LIMIT ?',
+            params: [1, 10],
+        })
+    })
 })
 
 describe('StarbasePluginRegistry', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -89,7 +89,6 @@ export class StarbasePluginRegistry {
                 dataSource: opts.dataSource,
                 config: opts.config,
             })
-            await plugin.beforeQuery(opts)
             sql = modified.sql
             params = modified.params
         }


### PR DESCRIPTION
/claim #71

This PR fixes a small regression in `StarbasePluginRegistry.beforeQuery` so each plugin hook receives the previous hook output exactly once, and adds a focused regression test that asserts call counts and arguments across multiple plugins.

## What changed
- Removed the duplicate `await plugin.beforeQuery(opts)` call that re-ran every hook with the original query.
- Added a regression test proving:
  - each `beforeQuery` hook is called exactly once;
  - the second hook receives the first hook's modified SQL/params;
  - the final return value is the last hook output.

## Demo video

Short local verification demo: https://github.com/kingzzoov-ctrl/starbasedb/releases/tag/starbasedb-pr162-demo-2026-05-13

Artifact details:
- File: `starbasedb-pr162-demo-2026-05-13.mp4`
- Duration: 12s
- Size: 106,802 bytes
- SHA-256: `34e4f9abce0a4090ceb74c9237fe1859530581ea98e0f326a4ac06b9794ba30e`

## Demo / verification transcript

```console
$ npx pnpm@9.15.9 exec vitest run src/plugin.test.ts --coverage.enabled false
RUN  v2.1.8 /root/revenue-agent/work/starbasedb

✓ src/plugin.test.ts (9 tests) 16ms

Test Files  1 passed (1)
Tests  9 passed (9)
```

```console
$ git diff --check
# no output; whitespace check passed
```

## Notes
- Scope is intentionally narrow: one production-line fix plus one focused regression test.
- I posted `/attempt #71` in the issue thread before opening this PR.
- The repository still has unrelated pre-existing TypeScript/lint issues in other files, so the focused plugin test is the validation target for this change.
