### PR TITLE
test: cover SQL dump import edge cases

### DIFF
--- a/src/import/dump.test.ts
+++ b/src/import/dump.test.ts
@@ -24,6 +24,7 @@ let mockConfig: StarbaseDBConfiguration
 
 beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(executeOperation).mockResolvedValue({ ok: true } as any)
 
     mockDataSource = {
         source: 'internal',
@@ -164,9 +165,15 @@ describe('Import Dump Module', () => {
         expect(jsonResponse.error).toBe('No SQL file uploaded')
     })
 
-    it('should remove SQLite format header if present', async () => {
+    it('should remove the SQLite format header before executing statements', async () => {
         const sqlFile = new File(
-            ['CREATE TABLE users (id INT, name TEXT);'],
+            [
+                [
+                    'SQLite format 3',
+                    'CREATE TABLE users (id INTEGER PRIMARY KEY);',
+                    'INSERT INTO users (id) VALUES (1);',
+                ].join('\n'),
+            ],
             'dump.sql',
             { type: 'application/sql' }
         )
@@ -179,14 +186,227 @@ describe('Import Dump Module', () => {
         )
 
         expect(response.status).toBe(200)
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            1,
+            [{ sql: 'CREATE TABLE users (id INTEGER PRIMARY KEY);' }],
+            mockDataSource,
+            mockConfig
+        )
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            2,
+            [{ sql: 'INSERT INTO users (id) VALUES (1);' }],
+            mockDataSource,
+            mockConfig
+        )
+
         const jsonResponse = (await response.json()) as {
-            result: { details: { statement: string }[] }
+            result: { message: string; details: { statement: string }[] }
         }
 
-        expect(jsonResponse.result.details.length).toBe(1)
-        expect(jsonResponse.result.details[0].statement).toBe(
-            'CREATE TABLE users (id INT, name TEXT);'
+        expect(jsonResponse.result.message).toBe(
+            'SQL dump import completed. 2 statements succeeded, 0 failed.'
         )
+        expect(jsonResponse.result.details).toHaveLength(2)
+        expect(
+            jsonResponse.result.details.some((detail) =>
+                detail.statement.includes('SQLite format 3')
+            )
+        ).toBe(false)
+    })
+
+    it('should parse comments blank lines multiline statements and final statement without semicolon', async () => {
+        const sqlContent = [
+            '-- dump comment',
+            '',
+            'CREATE TABLE users (',
+            '  id INTEGER PRIMARY KEY,',
+            '  name TEXT',
+            ');',
+            '-- seed data',
+            'INSERT INTO users (id, name)',
+            "VALUES (1, 'Ada');",
+            'CREATE INDEX idx_users_name ON users(name)',
+        ].join('\n')
+        const sqlFile = new File([sqlContent], 'dump.sql', {
+            type: 'application/sql',
+        })
+
+        const request = await createFormDataRequest(sqlFile)
+        const response = await importDumpRoute(
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(200)
+        expect(executeOperation).toHaveBeenCalledTimes(3)
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            1,
+            [
+                {
+                    sql: [
+                        'CREATE TABLE users (',
+                        '  id INTEGER PRIMARY KEY,',
+                        '  name TEXT',
+                        ');',
+                    ].join('\n'),
+                },
+            ],
+            mockDataSource,
+            mockConfig
+        )
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            2,
+            [
+                {
+                    sql: [
+                        'INSERT INTO users (id, name)',
+                        "VALUES (1, 'Ada');",
+                    ].join('\n'),
+                },
+            ],
+            mockDataSource,
+            mockConfig
+        )
+        expect(executeOperation).toHaveBeenNthCalledWith(
+            3,
+            [{ sql: 'CREATE INDEX idx_users_name ON users(name)' }],
+            mockDataSource,
+            mockConfig
+        )
+    })
+
+    it('should accept comments-only dumps without executing statements', async () => {
+        const sqlFile = new File(
+            [['-- only comments', '', '-- no SQL here'].join('\n')],
+            'dump.sql',
+            { type: 'application/sql' }
+        )
+
+        const request = await createFormDataRequest(sqlFile)
+        const response = await importDumpRoute(
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(200)
+        expect(executeOperation).not.toHaveBeenCalled()
+
+        const jsonResponse = (await response.json()) as {
+            result: { message: string; details: unknown[] }
+        }
+        expect(jsonResponse.result.message).toBe(
+            'SQL dump import completed. 0 statements succeeded, 0 failed.'
+        )
+        expect(jsonResponse.result.details).toEqual([])
+    })
+
+    it('should return 207 with details for mixed statement results', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ rowsAffected: 0 }] as any)
+            .mockRejectedValueOnce(new Error('insert failed'))
+
+        try {
+            const sqlFile = new File(
+                [
+                    [
+                        'CREATE TABLE users (id INTEGER);',
+                        'INSERT INTO users VALUES (1);',
+                    ].join('\n'),
+                ],
+                'dump.sql',
+                { type: 'application/sql' }
+            )
+
+            const request = await createFormDataRequest(sqlFile)
+            const response = await importDumpRoute(
+                request,
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(response.status).toBe(207)
+            const jsonResponse = (await response.json()) as {
+                result: {
+                    message: string
+                    details: {
+                        statement: string
+                        success: boolean
+                        result?: unknown
+                        error?: string
+                    }[]
+                }
+            }
+            expect(jsonResponse.result.message).toBe(
+                'SQL dump import completed. 1 statements succeeded, 1 failed.'
+            )
+            expect(jsonResponse.result.details).toEqual([
+                {
+                    statement: 'CREATE TABLE users (id INTEGER);',
+                    success: true,
+                    result: [{ rowsAffected: 0 }],
+                },
+                {
+                    statement: 'INSERT INTO users VALUES (1);',
+                    success: false,
+                    error: 'insert failed',
+                },
+            ])
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
+    })
+
+    it('should return 500 when multipart parsing fails', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const request = {
+            method: 'POST',
+            headers: new Headers({
+                'Content-Type': 'multipart/form-data; boundary=broken',
+            }),
+            formData: vi.fn().mockRejectedValue(new Error('bad multipart')),
+        } as unknown as Request
+
+        try {
+            const response = await importDumpRoute(
+                request,
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(response.status).toBe(500)
+            expect(executeOperation).not.toHaveBeenCalled()
+            const jsonResponse = (await response.json()) as { error: string }
+            expect(jsonResponse.error).toBe('bad multipart')
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
+    })
+
+    it('should reject sqlFile form values that are not files', async () => {
+        const formData = new FormData()
+        formData.append('sqlFile', 'not-a-file')
+        const request = new Request('http://localhost', {
+            method: 'POST',
+            body: formData,
+        })
+
+        const response = await importDumpRoute(
+            request,
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(400)
+        expect(executeOperation).not.toHaveBeenCalled()
+        const jsonResponse = (await response.json()) as { error: string }
+        expect(jsonResponse.error).toBe('No SQL file uploaded')
     })
 
     it('should return 207 if an unexpected error occurs', async () => {
@@ -198,17 +418,21 @@ describe('Import Dump Module', () => {
             throw new Error('Unexpected server crash')
         })
 
-        const sqlFile = new File(['SELECT * FROM users;'], 'dump.sql', {
-            type: 'application/sql',
-        })
+        try {
+            const sqlFile = new File(['SELECT * FROM users;'], 'dump.sql', {
+                type: 'application/sql',
+            })
 
-        const request = await createFormDataRequest(sqlFile)
-        const response = await importDumpRoute(
-            request,
-            mockDataSource,
-            mockConfig
-        )
+            const request = await createFormDataRequest(sqlFile)
+            const response = await importDumpRoute(
+                request,
+                mockDataSource,
+                mockConfig
+            )
 
-        expect(response.status).toBe(207)
+            expect(response.status).toBe(207)
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 })


### PR DESCRIPTION
/claim #71

## Summary

Adds focused Vitest coverage for SQL dump import behavior in `src/import/dump.ts`.

Covered behavior:
- strips an actual `SQLite format 3` header before execution
- parses multiline SQL statements while skipping comments and blank lines
- executes a final statement without a trailing semicolon
- accepts comments-only dumps without executing statements
- returns `207` with accurate details for mixed success/failure execution
- returns `500` when multipart parsing fails
- rejects non-File `sqlFile` form values
- restores the final `console.error` spy to avoid mock leakage

This is test-only and intentionally avoids the active CSV, JSON, RLS, cache, operation, worker, handler, allowlist, Durable Object, and plugin coverage PR areas.

## Verification

- `corepack pnpm exec vitest run src/import/dump.test.ts` - 13 passed
- `corepack pnpm exec vitest run src/import/dump.test.ts --coverage.enabled true --coverage.include src/import/dump.ts --coverage.reporter text --coverage.thresholds.lines=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0` - `src/import/dump.ts` at 100% statements, 96.15% branches, 100% functions, 100% lines
- `corepack pnpm exec prettier --check src/import/dump.test.ts` - passed
- `git diff --check -- src/import/dump.test.ts` - passed with CRLF warning only
- `corepack pnpm exec vitest run` - dump tests pass; existing unrelated RLS failures remain in `src/rls/index.test.ts`

## Demo video

- Short terminal demo: https://raw.githubusercontent.com/kaziiza/starbasedb/demo-dump-import-coverage-71/demo/starbasedb-dump-import-coverage-demo.mp4