### PR TITLE
test: cover export route edge cases

### DIFF
--- a/src/export/csv.test.ts
+++ b/src/export/csv.test.ts
@@ -148,6 +148,36 @@ describe('CSV Export Module', () => {
         expect(response.headers.get('Content-Type')).toBe('text/csv')
     })
 
+    it('should escape multiline CSV values and keep primitive values stable', async () => {
+        vi.mocked(getTableData).mockResolvedValue([
+            {
+                id: 1,
+                active: true,
+                notes: 'first line\nsecond line',
+                nullable: null,
+            },
+        ])
+
+        vi.mocked(createExportResponse).mockReturnValue(
+            new Response('mocked-csv-content', {
+                headers: { 'Content-Type': 'text/csv' },
+            })
+        )
+
+        const response = await exportTableToCsvRoute(
+            'mixed_values',
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(createExportResponse).toHaveBeenCalledWith(
+            'id,active,notes,nullable\n1,true,"first line\nsecond line",\n',
+            'mixed_values_export.csv',
+            'text/csv'
+        )
+        expect(response.headers.get('Content-Type')).toBe('text/csv')
+    })
+
     it('should return 500 on an unexpected error', async () => {
         const consoleErrorMock = vi
             .spyOn(console, 'error')

--- a/src/export/index.test.ts
+++ b/src/export/index.test.ts
@@ -60,6 +60,24 @@ describe('Database Operations Module', () => {
 
             expect(result).toEqual([])
         })
+
+        it('should return non-array transaction results unchanged', async () => {
+            const rawResult = [{ changes: 2, lastInsertRowid: 42 }]
+            vi.mocked(executeTransaction).mockResolvedValue(rawResult)
+
+            const result = await executeOperation(
+                [
+                    {
+                        sql: 'INSERT INTO users (name) VALUES (?)',
+                        params: ['Alice'],
+                    },
+                ],
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(result).toEqual(rawResult)
+        })
     })
 
     describe('getTableData', () => {
@@ -81,6 +99,23 @@ describe('Database Operations Module', () => {
                 { id: 1, name: 'Alice' },
                 { id: 2, name: 'Bob' },
             ])
+            expect(executeTransaction).toHaveBeenNthCalledWith(1, {
+                queries: [
+                    {
+                        sql: `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`,
+                        params: ['users'],
+                    },
+                ],
+                isRaw: false,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
+            expect(executeTransaction).toHaveBeenNthCalledWith(2, {
+                queries: [{ sql: 'SELECT * FROM users;' }],
+                isRaw: false,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
         })
 
         it('should return null if table does not exist', async () => {
@@ -153,6 +188,16 @@ describe('Database Operations Module', () => {
             expect(response.headers.get('Content-Disposition')).toBe(
                 'attachment; filename="notes.txt"'
             )
+        })
+
+        it('should preserve exported response body content', async () => {
+            const response = createExportResponse(
+                '{"ok":true}',
+                'payload.json',
+                'application/json'
+            )
+
+            expect(await response.text()).toBe('{"ok":true}')
         })
     })
 })

--- a/src/export/json.test.ts
+++ b/src/export/json.test.ts
@@ -136,6 +136,57 @@ describe('JSON Export Module', () => {
         expect(response.headers.get('Content-Type')).toBe('application/json')
     })
 
+    it('should preserve nulls, booleans, and nested values in the exported JSON body', async () => {
+        const mixedData = [
+            {
+                id: 1,
+                active: false,
+                metadata: { role: 'owner', tags: ['alpha'] },
+                deleted_at: null,
+            },
+        ]
+        vi.mocked(getTableData).mockResolvedValue(mixedData)
+
+        vi.mocked(createExportResponse).mockReturnValue(
+            new Response('mocked-json-content', {
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+
+        const response = await exportTableToJsonRoute(
+            'mixed_values',
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(createExportResponse).toHaveBeenCalledWith(
+            JSON.stringify(mixedData, null, 4),
+            'mixed_values_export.json',
+            'application/json'
+        )
+        expect(response.headers.get('Content-Type')).toBe('application/json')
+    })
+
+    it('should return 500 if JSON serialization fails', async () => {
+        const consoleErrorMock = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        vi.mocked(getTableData).mockResolvedValue([
+            { id: 1, unsupported: BigInt(1) },
+        ])
+
+        const response = await exportTableToJsonRoute(
+            'unsupported_values',
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(response.status).toBe(500)
+        const jsonResponse = (await response.json()) as { error: string }
+        expect(jsonResponse.error).toBe('Failed to export table to JSON')
+        expect(consoleErrorMock).toHaveBeenCalled()
+    })
+
     it('should return a 500 response when an error occurs', async () => {
         const consoleErrorMock = vi
             .spyOn(console, 'error')


### PR DESCRIPTION
/claim #71

Summary: Added focused export coverage for src/export/index.ts, CSV multiline/primitive export behavior, and JSON nested/null/serialization-failure behavior. Verification: targeted vitest export tests passed (23 tests), prettier check passed, git diff --check passed. Full vitest run currently fails on existing unrelated src/rls/index.test.ts assertions where policy WHERE clauses are not injected. AI-assisted with Codex; reviewed and scoped to the non-overlapping export coverage slice from my attempt comment.