### PR TITLE
test: cover plugin utility edges

### DIFF
--- a/plugins/cron/utils.test.ts
+++ b/plugins/cron/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { getNextExecutionTime, parseCronExpression } from './utils'
+
+describe('cron utils', () => {
+    it('parses valid cron expressions', () => {
+        const interval = parseCronExpression('*/15 * * * *')
+
+        expect(interval.next().getTime()).toBeGreaterThan(Date.now())
+    })
+
+    it('throws for invalid cron expressions', () => {
+        expect(() => parseCronExpression('not a cron')).toThrow()
+    })
+
+    it('returns the next execution time after the provided timestamp', () => {
+        const after = Date.UTC(2026, 0, 1, 0, 0, 30)
+        const nextExecution = getNextExecutionTime('* * * * *', after)
+
+        expect(nextExecution).toBe(Date.UTC(2026, 0, 1, 0, 1, 0))
+    })
+})

--- a/plugins/resend/index.test.ts
+++ b/plugins/resend/index.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ResendPlugin } from './index'
+
+describe('ResendPlugin', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('sends email requests with the configured API key and payload', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ id: 'email_123' }), {
+                status: 200,
+            })
+        )
+        vi.stubGlobal('fetch', fetchMock)
+
+        const plugin = new ResendPlugin({ apiKey: 'resend-secret' })
+        const response = await plugin.sendEmail(
+            'from@example.com',
+            ['to@example.com'],
+            'Subject',
+            '<p>Hello</p>'
+        )
+
+        expect(response).toEqual({ id: 'email_123' })
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.resend.com/emails',
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer resend-secret',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    from: 'from@example.com',
+                    to: ['to@example.com'],
+                    subject: 'Subject',
+                    html: '<p>Hello</p>',
+                }),
+            }
+        )
+    })
+
+    it('throws the Resend error message when the API rejects the request', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ message: 'Invalid API key' }), {
+                    status: 401,
+                })
+            )
+        )
+
+        const plugin = new ResendPlugin({ apiKey: 'bad-key' })
+
+        await expect(
+            plugin.sendEmail(
+                'from@example.com',
+                ['to@example.com'],
+                'Subject',
+                '<p>Hello</p>'
+            )
+        ).rejects.toThrow('Invalid API key')
+    })
+
+    it('uses a fallback error message when the API error body has no message', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({}), {
+                    status: 500,
+                })
+            )
+        )
+
+        const plugin = new ResendPlugin({ apiKey: 'resend-secret' })
+
+        await expect(
+            plugin.sendEmail(
+                'from@example.com',
+                ['to@example.com'],
+                'Subject',
+                '<p>Hello</p>'
+            )
+        ).rejects.toThrow('Failed to send email')
+    })
+})


### PR DESCRIPTION
﻿/claim #71

## Summary
- Add focused Vitest coverage for `plugins/cron/utils.ts`, covering valid schedule parsing, invalid cron strings, and next-execution calculation from a fixed timestamp.
- Add focused Vitest coverage for `plugins/resend/index.ts`, covering the request payload/auth headers, Resend API error propagation, and the fallback error message.
- Keep this test-only and non-overlapping with the active src route/import/export/handler/worker/DO/operation/plugin-registry coverage PRs.

## Validation
- `.\node_modules\.bin\vitest.cmd run plugins\cron\utils.test.ts plugins\resend\index.test.ts --coverage.enabled true --coverage.include plugins/cron/utils.ts --coverage.include plugins/resend/index.ts --coverage.reporter text` - passed; both files report 100% statements/branches/functions/lines
- `.\node_modules\.bin\prettier.cmd --check plugins\cron\utils.test.ts plugins\resend\index.test.ts` - passed
- `git diff --check` - passed

## Demo video
- Short proof video: https://github.com/Iineman2/starbasedb/releases/download/starbasedb-71-maintenance-demos/starbasedb-pr168-plugin-utils-demo.mp4
- This is plugin/unit-test-only coverage, so the video is a reviewer walkthrough of the covered cron/Resend paths and local verification rather than a UI flow.
