### PR TITLE
test: cover sql macros plugin

### DIFF
--- a/plugins/sql-macros/index.test.ts
+++ b/plugins/sql-macros/index.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SqlMacrosPlugin } from './index'
+import type { DataSource } from '../../src/types'
+
+const createInternalDataSource = (columns = ['id', 'name', 'email']) =>
+    ({
+        source: 'internal',
+        rpc: {
+            executeQuery: vi
+                .fn()
+                .mockResolvedValue(
+                    columns.map((column_name) => ({ column_name }))
+                ),
+        },
+    }) as unknown as DataSource
+
+describe('SqlMacrosPlugin', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('stores the current config during registration middleware', async () => {
+        const plugin = new SqlMacrosPlugin()
+        const config = { role: 'admin' }
+        const next = vi.fn()
+        const app = {
+            use: vi.fn((middleware) =>
+                middleware({ get: vi.fn(() => config) }, next)
+            ),
+        } as any
+
+        await plugin.register(app)
+
+        expect(app.use).toHaveBeenCalledTimes(1)
+        expect(plugin.config).toBe(config)
+        expect(next).toHaveBeenCalled()
+    })
+
+    it('leaves queries unchanged when no data source is available', async () => {
+        const plugin = new SqlMacrosPlugin({ preventSelectStar: true })
+
+        await expect(
+            plugin.beforeQuery({
+                sql: 'SELECT * FROM users',
+                params: [1],
+            })
+        ).resolves.toEqual({
+            sql: 'SELECT * FROM users',
+            params: [1],
+        })
+    })
+
+    it('replaces $_exclude with explicit internal table columns', async () => {
+        const plugin = new SqlMacrosPlugin()
+        const dataSource = createInternalDataSource([
+            'id',
+            'name',
+            'email',
+            'created_at',
+        ])
+
+        const result = await plugin.beforeQuery({
+            sql: 'SELECT $_exclude(email, created_at) FROM users',
+            dataSource,
+        })
+
+        expect(dataSource.rpc.executeQuery).toHaveBeenCalledWith({
+            sql: expect.stringContaining("pragma_table_info('users')"),
+        })
+        expect(result.sql).toBe('SELECT `id`, `name` FROM `users`')
+    })
+
+    it('keeps non-internal, pragma, and non-select queries unchanged', async () => {
+        const plugin = new SqlMacrosPlugin()
+        const externalDataSource = {
+            source: 'postgresql',
+            rpc: { executeQuery: vi.fn() },
+        } as unknown as DataSource
+        const internalDataSource = createInternalDataSource()
+
+        await expect(
+            plugin.beforeQuery({
+                sql: 'SELECT $_exclude(email) FROM users',
+                dataSource: externalDataSource,
+            })
+        ).resolves.toEqual({
+            sql: 'SELECT $_exclude(email) FROM users',
+            params: undefined,
+        })
+
+        await expect(
+            plugin.beforeQuery({
+                sql: "SELECT name FROM pragma_table_info('users')",
+                dataSource: internalDataSource,
+            })
+        ).resolves.toEqual({
+            sql: "SELECT name FROM pragma_table_info('users')",
+            params: undefined,
+        })
+
+        await expect(
+            plugin.beforeQuery({
+                sql: 'UPDATE users SET name = ? WHERE id = ?',
+                params: ['Ada', 1],
+                dataSource: internalDataSource,
+            })
+        ).resolves.toEqual({
+            sql: 'UPDATE users SET name = ? WHERE id = ?',
+            params: ['Ada', 1],
+        })
+    })
+
+    it('blocks SELECT * for non-admin users when enabled', async () => {
+        const plugin = new SqlMacrosPlugin({ preventSelectStar: true })
+        plugin.config = { role: 'user' } as any
+
+        await expect(
+            plugin.beforeQuery({
+                sql: 'SELECT * FROM users',
+                dataSource: createInternalDataSource(),
+            })
+        ).rejects.toThrow(
+            'SELECT * is not allowed. Please specify explicit columns.'
+        )
+    })
+
+    it('allows SELECT * for admins and when prevention is disabled', async () => {
+        const adminPlugin = new SqlMacrosPlugin({ preventSelectStar: true })
+        adminPlugin.config = { role: 'admin' } as any
+
+        await expect(
+            adminPlugin.beforeQuery({
+                sql: 'SELECT * FROM users',
+                dataSource: createInternalDataSource(),
+            })
+        ).resolves.toEqual({
+            sql: 'SELECT * FROM users',
+            params: undefined,
+        })
+
+        const disabledPlugin = new SqlMacrosPlugin({ preventSelectStar: false })
+        disabledPlugin.config = { role: 'user' } as any
+
+        await expect(
+            disabledPlugin.beforeQuery({
+                sql: 'SELECT * FROM users',
+                dataSource: createInternalDataSource(),
+            })
+        ).resolves.toEqual({
+            sql: 'SELECT * FROM users',
+            params: undefined,
+        })
+    })
+
+    it('returns original SQL and logs when exclude schema lookup fails', async () => {
+        const plugin = new SqlMacrosPlugin()
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const dataSource = createInternalDataSource()
+        vi.mocked(dataSource.rpc.executeQuery).mockRejectedValueOnce(
+            new Error('schema unavailable')
+        )
+
+        const result = await plugin.beforeQuery({
+            sql: 'SELECT $_exclude(email) FROM users',
+            dataSource,
+        })
+
+        expect(result.sql).toBe('SELECT $_exclude(email) FROM users')
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'SQL parsing error:',
+            expect.any(Error)
+        )
+    })
+})

--- a/plugins/sql-macros/index.ts
+++ b/plugins/sql-macros/index.ts
@@ -8,6 +8,8 @@ import { DataSource, QueryResult } from '../../src/types'
 
 const parser = new (require('node-sql-parser').Parser)()
 
+const firstStatement = (ast: any) => (Array.isArray(ast) ? ast[0] : ast)
+
 export class SqlMacrosPlugin extends StarbasePlugin {
     config?: StarbaseDBConfiguration
 
@@ -59,7 +61,7 @@ export class SqlMacrosPlugin extends StarbasePlugin {
 
     private checkSelectStar(sql: string, params?: unknown[]): string {
         try {
-            const ast = parser.astify(sql)[0]
+            const ast = firstStatement(parser.astify(sql))
 
             // Only check SELECT statements
             if (ast.type === 'select') {
@@ -116,7 +118,7 @@ export class SqlMacrosPlugin extends StarbasePlugin {
                 '$_exclude',
                 '__exclude'
             )
-            const normalizedQuery = parser.astify(preparedSql)[0]
+            const normalizedQuery = firstStatement(parser.astify(preparedSql))
 
             // Only process SELECT statements
             if (normalizedQuery.type !== 'select') {


### PR DESCRIPTION
/claim #71

## Summary
- Add focused Vitest coverage for `plugins/sql-macros/index.ts`.
- Cover SQL macros registration, `$_exclude` expansion, no-data-source behavior, external-source/pragma/non-select bypasses, schema lookup fallback, and `SELECT *` enforcement.
- Fix parser AST normalization so `SELECT *` prevention works whether `node-sql-parser` returns a single statement object or an array.

This is a small SQL macros slice that is non-overlapping with the active/rewarded Durable Object, import/export, LiteREST, handler, worker, operation, cache, RLS, allowlist, plugin registry, stats, cron/resend, and API response coverage PRs.

## Validation
- `.\node_modules\.bin\prettier.CMD --write plugins\sql-macros\index.ts plugins\sql-macros\index.test.ts` - passed
- `.\node_modules\.bin\vitest.CMD run plugins\sql-macros\index.test.ts --coverage.enabled true --coverage.include plugins/sql-macros/index.ts --coverage.reporter text --coverage.reportsDirectory coverage-sql-macros` - passed; `plugins/sql-macros/index.ts` reports 91.93% statements, 85.29% branches, 100% functions, 91.8% lines
- `git diff --check` - passed

No UI demo video is included because this is plugin/unit-test coverage with no visible UI behavior.

AI-assisted with Codex; I reviewed the diff and kept the scope to this SQL macros coverage/fix slice.