### PR TITLE
[codex] add cron utility tests

### DIFF
--- a/plugins/cron/utils.test.ts
+++ b/plugins/cron/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getNextExecutionTime, parseCronExpression } from './utils'
+
+describe('cron utils', () => {
+    it('parses valid cron expressions', () => {
+        const interval = parseCronExpression('*/15 * * * *')
+
+        expect(interval.next().getMinutes() % 15).toBe(0)
+    })
+
+    it('throws for invalid cron expressions', () => {
+        expect(() => parseCronExpression('not a cron')).toThrow()
+    })
+
+    it('returns the next execution time after the provided timestamp', () => {
+        const after = new Date(2026, 0, 1, 10, 30, 0).getTime()
+
+        expect(getNextExecutionTime('0 11 * * *', after)).toBe(
+            new Date(2026, 0, 1, 11, 0, 0).getTime()
+        )
+    })
+
+    it('rolls over to the next day when the scheduled time has passed', () => {
+        const after = new Date(2026, 0, 1, 11, 30, 0).getTime()
+
+        expect(getNextExecutionTime('0 11 * * *', after)).toBe(
+            new Date(2026, 0, 2, 11, 0, 0).getTime()
+        )
+    })
+})


### PR DESCRIPTION
## Summary

/claim #71

Adds focused Vitest coverage for the cron plugin utility helpers:

- verifies valid cron expressions can be parsed
- verifies invalid cron expressions throw
- verifies next execution time calculation for a same-day schedule
- verifies next execution time rolls over to the following day after the scheduled time has passed

## Validation

- `pnpm exec vitest run plugins/cron/utils.test.ts`

## Notes

I also ran the full test suite locally with `npx vitest run`. The new cron tests passed, but the full suite currently has unrelated pre-existing failures in `src/rls/index.test.ts` where RLS policy injection expectations receive unchanged SQL.
