### PR TITLE
test: cover query log failure paths

### DIFF
--- a/plugins/query-log/index.test.ts
+++ b/plugins/query-log/index.test.ts
@@ -115,6 +115,26 @@ describe('QueryLogPlugin - addQuery()', () => {
             params: ['SELECT * FROM test', 50],
         })
     })
+
+    it('should swallow insert failures and return an empty list', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        vi.mocked(mockDataSource.rpc.executeQuery).mockRejectedValueOnce(
+            new Error('insert failed')
+        )
+
+        queryLogPlugin['state'].query = 'SELECT * FROM failing_query'
+        queryLogPlugin['state'].totalTime = 25
+
+        await expect(
+            queryLogPlugin['addQuery'](mockDataSource)
+        ).resolves.toEqual([])
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error inserting rejected allowlist query:',
+            expect.any(Error)
+        )
+    })
 })
 
 describe('QueryLogPlugin - expireLog()', () => {
@@ -134,5 +154,21 @@ describe('QueryLogPlugin - expireLog()', () => {
 
         const result = await queryLogPlugin['expireLog']()
         expect(result).toBe(false)
+    })
+
+    it('should return false when log expiration fails', async () => {
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        vi.mocked(mockDataSource.rpc.executeQuery).mockRejectedValueOnce(
+            new Error('delete failed')
+        )
+        queryLogPlugin['dataSource'] = mockDataSource
+
+        await expect(queryLogPlugin['expireLog']()).resolves.toBe(false)
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error purging old query logs:',
+            expect.any(Error)
+        )
     })
 })


### PR DESCRIPTION
## Summary
- adds focused Vitest coverage for QueryLogPlugin failure paths
- verifies `addQuery` swallows insert failures and returns `[]`
- verifies `expireLog` returns `false` and logs when deletion fails

## Related issue
Part of #71

## Verification
- `pnpm vitest run plugins/query-log/index.test.ts`
- `pnpm exec prettier --check plugins/query-log/index.test.ts`
- `git diff --check`

## Notes
- `pnpm test run` currently has existing failures in `src/rls/index.test.ts` on main (4 RLS policy assertion failures). The query-log test file itself passes locally: 10/10.

/claim #71
