### PR TITLE
test: cover response and CORS helpers

### DIFF
--- a/src/cors.test.ts
+++ b/src/cors.test.ts
@@ -13,6 +13,20 @@ test('it should return a Response instance with correct headers', () => {
     expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         corsHeaders['Access-Control-Allow-Headers']
     )
+    expect(response.headers.get('Access-Control-Max-Age')).toBe(
+        corsHeaders['Access-Control-Max-Age']
+    )
     expect(response.status).toBe(204)
     expect(response.body).toBeNull()
+})
+
+test('corsHeaders expose the expected CORS contract', () => {
+    expect(corsHeaders).toEqual({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods':
+            'GET, POST, PATCH, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers':
+            'Authorization, Content-Type, X-Starbase-Source, X-Data-Source',
+        'Access-Control-Max-Age': '86400',
+    })
 })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,6 +11,8 @@ test('createResponse returns success response with data', async () => {
     })
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
 })
 
 test('createResponse returns error response', async () => {
@@ -22,4 +24,14 @@ test('createResponse returns error response', async () => {
     })
 
     expect(response.status).toBe(500)
+})
+
+test('createResponse preserves explicit result and error keys when both are present', async () => {
+    const response = createResponse({ ok: false }, 'Bad request', 400)
+
+    expect(await response.json()).toEqual({
+        result: { ok: false },
+        error: 'Bad request',
+    })
+    expect(response.status).toBe(400)
 })


### PR DESCRIPTION
## Summary
- cover JSON response headers and explicit result/error payloads
- cover the full exported CORS header contract, including max age

## Verification
- `pnpm vitest run src/utils.test.ts src/cors.test.ts`
- `pnpm exec prettier --check src/utils.test.ts src/cors.test.ts`
- `git diff --check`

/claim #71