### PR TITLE
test: cover handler query validation

### DIFF
--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -123,6 +123,24 @@ describe('StarbaseDB Middleware & Request Handling', () => {
 })
 
 describe('StarbaseDB Query Execution', () => {
+    it('should reject query requests without JSON content type', async () => {
+        const request = new Request('https://example.com/query', {
+            method: 'POST',
+            body: 'SELECT * FROM users',
+            headers: { 'Content-Type': 'text/plain' },
+        })
+
+        const response = await instance.queryRoute(request, false)
+
+        expect(createResponse).toHaveBeenCalledWith(
+            undefined,
+            'Content-Type must be application/json.',
+            400
+        )
+        expect(response.status).toBe(400)
+        expect(executeQuery).not.toHaveBeenCalled()
+    })
+
     it('should execute a valid SQL query', async () => {
         const request = new Request('https://example.com/query', {
             method: 'POST',
@@ -154,19 +172,95 @@ describe('StarbaseDB Query Execution', () => {
         expect(response.status).toBe(400)
     })
 
-    it('should execute a SQL transaction', async () => {
+    it('should reject invalid query params', async () => {
         const request = new Request('https://example.com/query', {
             method: 'POST',
             body: JSON.stringify({
-                transaction: [{ sql: "INSERT INTO users VALUES (1, 'Alice')" }],
+                sql: 'SELECT * FROM users WHERE id = ?',
+                params: '1',
             }),
             headers: { 'Content-Type': 'application/json' },
         })
 
         const response = await instance.queryRoute(request, false)
 
-        expect(executeTransaction).toHaveBeenCalled()
+        expect(createResponse).toHaveBeenCalledWith(
+            undefined,
+            'Invalid "params" field. Must be an array or object.',
+            400
+        )
+        expect(response.status).toBe(400)
+        expect(executeQuery).not.toHaveBeenCalled()
+    })
+
+    it('should execute a SQL transaction', async () => {
+        const request = new Request('https://example.com/query', {
+            method: 'POST',
+            body: JSON.stringify({
+                transaction: [
+                    {
+                        sql: "INSERT INTO users VALUES (?, 'Alice')",
+                        params: [1],
+                    },
+                ],
+            }),
+            headers: { 'Content-Type': 'application/json' },
+        })
+
+        const response = await instance.queryRoute(request, true)
+
+        expect(executeTransaction).toHaveBeenCalledWith({
+            queries: [
+                {
+                    sql: "INSERT INTO users VALUES (?, 'Alice')",
+                    params: [1],
+                },
+            ],
+            isRaw: true,
+            dataSource: mockDataSource,
+            config: mockConfig,
+        })
         expect(response.status).toBe(200)
+    })
+
+    it('should reject transactions with an empty SQL statement', async () => {
+        const request = new Request('https://example.com/query', {
+            method: 'POST',
+            body: JSON.stringify({
+                transaction: [{ sql: '   ' }],
+            }),
+            headers: { 'Content-Type': 'application/json' },
+        })
+
+        const response = await instance.queryRoute(request, false)
+
+        expect(createResponse).toHaveBeenCalledWith(
+            undefined,
+            'Invalid or empty "sql" field in transaction.',
+            400
+        )
+        expect(response.status).toBe(400)
+        expect(executeTransaction).not.toHaveBeenCalled()
+    })
+
+    it('should reject transactions with invalid params', async () => {
+        const request = new Request('https://example.com/query', {
+            method: 'POST',
+            body: JSON.stringify({
+                transaction: [{ sql: 'SELECT * FROM users', params: 'bad' }],
+            }),
+            headers: { 'Content-Type': 'application/json' },
+        })
+
+        const response = await instance.queryRoute(request, false)
+
+        expect(createResponse).toHaveBeenCalledWith(
+            undefined,
+            'Invalid "params" field in transaction. Must be an array or object.',
+            400
+        )
+        expect(response.status).toBe(400)
+        expect(executeTransaction).not.toHaveBeenCalled()
     })
 })
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -316,25 +316,31 @@ export class StarbaseDB {
                 (await request.json()) as QueryRequest & QueryTransactionRequest
 
             if (Array.isArray(transaction) && transaction.length) {
-                const queries = transaction.map((queryObj: any) => {
+                const queries = []
+
+                for (const queryObj of transaction) {
                     const { sql, params } = queryObj
 
                     if (typeof sql !== 'string' || !sql.trim()) {
-                        throw new Error(
-                            'Invalid or empty "sql" field in transaction.'
+                        return createResponse(
+                            undefined,
+                            'Invalid or empty "sql" field in transaction.',
+                            400
                         )
                     } else if (
                         params !== undefined &&
                         !Array.isArray(params) &&
                         typeof params !== 'object'
                     ) {
-                        throw new Error(
-                            'Invalid "params" field in transaction. Must be an array or object.'
+                        return createResponse(
+                            undefined,
+                            'Invalid "params" field in transaction. Must be an array or object.',
+                            400
                         )
                     }
 
-                    return { sql, params }
-                })
+                    queries.push({ sql, params })
+                }
 
                 const response = await executeTransaction({
                     queries,


### PR DESCRIPTION
/claim #71

## Summary
- Return `400` validation responses for malformed transaction SQL and params instead of falling through to the generic `500` error path.
- Expand `src/handler.test.ts` coverage for non-JSON query requests, invalid query params, raw transaction forwarding with params, invalid transaction SQL, and invalid transaction params.
- Keep this focused on handler query validation, separate from the handler route-gate coverage in #189.

## Verification
- `.\node_modules\.bin\vitest.cmd run src/handler.test.ts` -> 13 tests passed
- `.\node_modules\.bin\vitest.cmd run src/handler.test.ts --coverage.enabled true --coverage.include src/handler.ts --coverage.reporter text --coverage.thresholds.lines=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0` -> passed; `src/handler.ts` reports 59.63% statements / 63.33% branches / 29.62% functions / 61.32% lines in the focused run
- `.\node_modules\.bin\prettier.cmd --check src/handler.ts src/handler.test.ts` -> passed
- `git diff --check -- src/handler.ts src/handler.test.ts` -> passed with Windows CRLF warnings only
- `.\node_modules\.bin\vitest.cmd run` -> new handler tests pass; current main still has 4 unrelated baseline failures in `src/rls/index.test.ts`

## Notes
- No UI demo video is included because this is backend/unit-test-only validation coverage; the verification commands above demonstrate the behavior.
- Transparency: AI-assisted with Codex; I reviewed the diff and verified locally before submitting.