### PR TITLE
fix: stream SQL database dumps

### DIFF
--- a/src/export/dump.test.ts
+++ b/src/export/dump.test.ts
@@ -162,6 +162,48 @@ describe('Database Dump Module', () => {
         )
     })
 
+    it('should request the next data page only after the prior chunk is consumed', async () => {
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'events' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE events (id INTEGER, payload TEXT);' },
+            ])
+            .mockResolvedValueOnce([{ id: 1, payload: 'first' }])
+            .mockResolvedValueOnce([{ id: 2, payload: 'second' }])
+            .mockResolvedValueOnce([])
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+        const reader = response.body!.getReader()
+        const decoder = new TextDecoder()
+
+        expect(executeOperation).toHaveBeenCalledTimes(1)
+
+        expect(decoder.decode((await reader.read()).value)).toBe(
+            'SQLite format 3\0'
+        )
+        expect(decoder.decode((await reader.read()).value)).toContain(
+            'CREATE TABLE events'
+        )
+
+        await Promise.resolve()
+        expect(executeOperation).not.toHaveBeenCalledWith(
+            [
+                {
+                    sql: 'SELECT * FROM "events" LIMIT ? OFFSET ?;',
+                    params: [500, 500],
+                },
+            ],
+            mockDataSource,
+            mockConfig
+        )
+
+        expect(decoder.decode((await reader.read()).value)).toContain('first')
+
+        await reader.read()
+        await reader.read()
+        expect((await reader.read()).done).toBe(true)
+    })
+
     it('should return a 500 response when an error occurs', async () => {
         const consoleErrorMock = vi
             .spyOn(console, 'error')

--- a/src/export/dump.test.ts
+++ b/src/export/dump.test.ts
@@ -49,6 +49,7 @@ describe('Database Dump Module', () => {
                 { id: 1, name: 'Alice' },
                 { id: 2, name: 'Bob' },
             ])
+            .mockResolvedValueOnce([])
             .mockResolvedValueOnce([
                 { sql: 'CREATE TABLE orders (id INTEGER, total REAL);' },
             ])
@@ -56,6 +57,7 @@ describe('Database Dump Module', () => {
                 { id: 1, total: 99.99 },
                 { id: 2, total: 49.5 },
             ])
+            .mockResolvedValueOnce([])
 
         const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
 
@@ -71,13 +73,13 @@ describe('Database Dump Module', () => {
         expect(dumpText).toContain(
             'CREATE TABLE users (id INTEGER, name TEXT);'
         )
-        expect(dumpText).toContain("INSERT INTO users VALUES (1, 'Alice');")
-        expect(dumpText).toContain("INSERT INTO users VALUES (2, 'Bob');")
+        expect(dumpText).toContain('INSERT INTO "users" VALUES (1, \'Alice\');')
+        expect(dumpText).toContain('INSERT INTO "users" VALUES (2, \'Bob\');')
         expect(dumpText).toContain(
             'CREATE TABLE orders (id INTEGER, total REAL);'
         )
-        expect(dumpText).toContain('INSERT INTO orders VALUES (1, 99.99);')
-        expect(dumpText).toContain('INSERT INTO orders VALUES (2, 49.5);')
+        expect(dumpText).toContain('INSERT INTO "orders" VALUES (1, 99.99);')
+        expect(dumpText).toContain('INSERT INTO "orders" VALUES (2, 49.5);')
     })
 
     it('should handle empty databases (no tables)', async () => {
@@ -118,13 +120,45 @@ describe('Database Dump Module', () => {
                 { sql: 'CREATE TABLE users (id INTEGER, bio TEXT);' },
             ])
             .mockResolvedValueOnce([{ id: 1, bio: "Alice's adventure" }])
+            .mockResolvedValueOnce([])
 
         const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
 
         expect(response).toBeInstanceOf(Response)
         const dumpText = await response.text()
         expect(dumpText).toContain(
-            "INSERT INTO users VALUES (1, 'Alice''s adventure');"
+            "INSERT INTO \"users\" VALUES (1, 'Alice''s adventure');"
+        )
+    })
+
+    it('should read table rows in bounded pages', async () => {
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'events' }])
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE events (id INTEGER, payload TEXT);' },
+            ])
+            .mockResolvedValueOnce([{ id: 1, payload: 'first' }])
+            .mockResolvedValueOnce([{ id: 2, payload: 'second' }])
+            .mockResolvedValueOnce([])
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+        const dumpText = await response.text()
+
+        expect(dumpText).toContain(
+            'INSERT INTO "events" VALUES (1, \'first\');'
+        )
+        expect(dumpText).toContain(
+            'INSERT INTO "events" VALUES (2, \'second\');'
+        )
+        expect(executeOperation).toHaveBeenCalledWith(
+            [
+                {
+                    sql: 'SELECT * FROM "events" LIMIT ? OFFSET ?;',
+                    params: [500, 500],
+                },
+            ],
+            mockDataSource,
+            mockConfig
         )
     })
 

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -3,6 +3,45 @@ import { StarbaseDBConfiguration } from '../handler'
 import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
+const DEFAULT_DUMP_BATCH_SIZE = 500
+
+function quoteIdentifier(identifier: string): string {
+    return `"${identifier.replace(/"/g, '""')}"`
+}
+
+function toSqlHex(bytes: Uint8Array): string {
+    return Array.from(bytes)
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('')
+}
+
+function formatSqlValue(value: unknown): string {
+    if (value === null || value === undefined) return 'NULL'
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? String(value) : 'NULL'
+    }
+    if (typeof value === 'bigint') return value.toString()
+    if (typeof value === 'boolean') return value ? '1' : '0'
+    if (value instanceof ArrayBuffer) {
+        return `X'${toSqlHex(new Uint8Array(value))}'`
+    }
+    if (ArrayBuffer.isView(value)) {
+        return `X'${toSqlHex(
+            new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+        )}'`
+    }
+
+    return `'${String(value).replace(/'/g, "''")}'`
+}
+
+function buildInsertStatement(
+    table: string,
+    row: Record<string, unknown>
+): string {
+    const values = Object.values(row).map(formatSqlValue)
+    return `INSERT INTO ${quoteIdentifier(table)} VALUES (${values.join(', ')});\n`
+}
+
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
@@ -16,54 +55,76 @@ export async function dumpDatabaseRoute(
         )
 
         const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
+        const encoder = new TextEncoder()
+        const stream = new ReadableStream({
+            async start(controller) {
+                try {
+                    controller.enqueue(encoder.encode('SQLite format 3\0'))
 
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
+                    for (const table of tables) {
+                        const schemaResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name=?;`,
+                                    params: [table],
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
 
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
-            }
+                        if (schemaResult.length) {
+                            const schema = schemaResult[0].sql
+                            controller.enqueue(
+                                encoder.encode(
+                                    `\n-- Table: ${table}\n${schema};\n\n`
+                                )
+                            )
+                        }
 
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
+                        let offset = 0
+                        while (true) {
+                            const dataResult = await executeOperation(
+                                [
+                                    {
+                                        sql: `SELECT * FROM ${quoteIdentifier(table)} LIMIT ? OFFSET ?;`,
+                                        params: [
+                                            DEFAULT_DUMP_BATCH_SIZE,
+                                            offset,
+                                        ],
+                                    },
+                                ],
+                                dataSource,
+                                config
+                            )
 
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
+                            if (!dataResult.length) break
 
-            dumpContent += '\n'
-        }
+                            const chunk = dataResult
+                                .map((row: Record<string, unknown>) =>
+                                    buildInsertStatement(table, row)
+                                )
+                                .join('')
+                            controller.enqueue(encoder.encode(chunk))
+                            offset += DEFAULT_DUMP_BATCH_SIZE
+                        }
 
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
+                        controller.enqueue(encoder.encode('\n'))
+                    }
+
+                    controller.close()
+                } catch (error) {
+                    controller.error(error)
+                }
+            },
+        })
 
         const headers = new Headers({
             'Content-Type': 'application/x-sqlite3',
             'Content-Disposition': 'attachment; filename="database_dump.sql"',
         })
 
-        return new Response(blob, { headers })
+        return new Response(stream, { headers })
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -56,60 +56,73 @@ export async function dumpDatabaseRoute(
 
         const tables = tablesResult.map((row: any) => row.name)
         const encoder = new TextEncoder()
+        let headerSent = false
+        let tableIndex = 0
+        let schemaSent = false
+        let offset = 0
         const stream = new ReadableStream({
-            async start(controller) {
+            async pull(controller) {
                 try {
-                    controller.enqueue(encoder.encode('SQLite format 3\0'))
+                    if (!headerSent) {
+                        headerSent = true
+                        controller.enqueue(encoder.encode('SQLite format 3\0'))
+                        return
+                    }
 
-                    for (const table of tables) {
-                        const schemaResult = await executeOperation(
-                            [
-                                {
-                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name=?;`,
-                                    params: [table],
-                                },
-                            ],
-                            dataSource,
-                            config
-                        )
+                    while (tableIndex < tables.length) {
+                        const table = tables[tableIndex]
 
-                        if (schemaResult.length) {
-                            const schema = schemaResult[0].sql
-                            controller.enqueue(
-                                encoder.encode(
-                                    `\n-- Table: ${table}\n${schema};\n\n`
-                                )
-                            )
-                        }
-
-                        let offset = 0
-                        while (true) {
-                            const dataResult = await executeOperation(
+                        if (!schemaSent) {
+                            schemaSent = true
+                            const schemaResult = await executeOperation(
                                 [
                                     {
-                                        sql: `SELECT * FROM ${quoteIdentifier(table)} LIMIT ? OFFSET ?;`,
-                                        params: [
-                                            DEFAULT_DUMP_BATCH_SIZE,
-                                            offset,
-                                        ],
+                                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name=?;`,
+                                        params: [table],
                                     },
                                 ],
                                 dataSource,
                                 config
                             )
 
-                            if (!dataResult.length) break
+                            if (schemaResult.length) {
+                                const schema = schemaResult[0].sql
+                                controller.enqueue(
+                                    encoder.encode(
+                                        `\n-- Table: ${table}\n${schema};\n\n`
+                                    )
+                                )
+                                return
+                            }
+                        }
 
+                        const dataResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT * FROM ${quoteIdentifier(table)} LIMIT ? OFFSET ?;`,
+                                    params: [DEFAULT_DUMP_BATCH_SIZE, offset],
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
+
+                        if (dataResult.length) {
+                            offset += DEFAULT_DUMP_BATCH_SIZE
                             const chunk = dataResult
                                 .map((row: Record<string, unknown>) =>
                                     buildInsertStatement(table, row)
                                 )
                                 .join('')
                             controller.enqueue(encoder.encode(chunk))
-                            offset += DEFAULT_DUMP_BATCH_SIZE
+                            return
                         }
 
+                        tableIndex += 1
+                        schemaSent = false
+                        offset = 0
                         controller.enqueue(encoder.encode('\n'))
+                        return
                     }
 
                     controller.close()


### PR DESCRIPTION
/claim #59

## Summary

This is a focused streaming slice for the large database dump issue.

Instead of building the entire SQL dump in a single in-memory string/blob, `/export/dump` now returns a `ReadableStream` and writes the dump incrementally:
- emits the existing SQLite header first
- loads table schemas one table at a time
- reads table rows in bounded `LIMIT ? OFFSET ?` pages
- streams each batch of `INSERT` statements as it is produced
- quotes table identifiers and escapes SQL values, including `NULL`, booleans, bigint, and binary values
- preserves the existing download headers and response shape for callers

This does not attempt to solve the full async/R2 continuation path in one PR. It removes the immediate O(database dump size) string allocation while keeping the existing endpoint behavior intact, so it can compose with later R2/alarm work.

## Validation

- `./node_modules/.bin/prettier --check src/export/dump.ts src/export/dump.test.ts`
- `./node_modules/.bin/vitest run src/export/dump.test.ts` (6 tests)
- `git diff --check`

The repo-wide `./node_modules/.bin/tsc --noEmit` is still blocked by pre-existing type errors outside this PR (`src/do.ts`, `src/operation.ts`, existing tests). The focused dump tests and formatting checks pass.
