### PR TITLE
test: cover handler pre-auth plugin routing

### DIFF
--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -7,6 +7,7 @@ import { LiteREST } from './literest'
 import { createResponse } from './utils'
 import { corsPreflight } from './cors'
 import { StarbasePluginRegistry } from './plugin'
+import type { StarbasePlugin } from './plugin'
 
 vi.mock('./cors', () => ({
     corsPreflight: vi.fn().mockReturnValue(new Response(null, { status: 204 })),
@@ -178,6 +179,85 @@ describe('StarbaseDB Cache Expiry', () => {
             sql: 'DELETE FROM tmp_cache WHERE timestamp + (ttl * 1000) < ?',
             params: [expect.any(Number)],
         })
+    })
+})
+
+describe('StarbaseDB Pre-Auth Plugin Routing', () => {
+    function createInstanceWithPlugin(plugin: Partial<StarbasePlugin>) {
+        return new StarbaseDB({
+            dataSource: mockDataSource,
+            config: mockConfig,
+            plugins: [plugin as StarbasePlugin],
+        })
+    }
+
+    it('should route matching authless plugin paths before auth checks', async () => {
+        const authlessPlugin = {
+            opts: { requiresAuth: false },
+            pathPrefix: '/webhooks/:provider/*',
+        }
+        const preAuthInstance = createInstanceWithPlugin(authlessPlugin)
+        const request = new Request(
+            'https://example.com/webhooks/stripe/events/created'
+        )
+
+        const response = await preAuthInstance.handlePreAuth(
+            request,
+            mockExecutionContext
+        )
+
+        expect(preAuthInstance['app'].fetch).toHaveBeenCalledWith(request)
+        await expect(response?.text()).resolves.toBe('mock-response')
+    })
+
+    it('should skip authless plugins when the path does not match', async () => {
+        const authlessPlugin = {
+            opts: { requiresAuth: false },
+            pathPrefix: '/webhooks/:provider/*',
+        }
+        const preAuthInstance = createInstanceWithPlugin(authlessPlugin)
+        const request = new Request('https://example.com/query')
+
+        const response = await preAuthInstance.handlePreAuth(
+            request,
+            mockExecutionContext
+        )
+
+        expect(response).toBeUndefined()
+        expect(preAuthInstance['app'].fetch).not.toHaveBeenCalled()
+    })
+
+    it('should not route auth-required plugin paths before auth checks', async () => {
+        const authRequiredPlugin = {
+            opts: { requiresAuth: true },
+            pathPrefix: '/socket',
+        }
+        const preAuthInstance = createInstanceWithPlugin(authRequiredPlugin)
+        const request = new Request('https://example.com/socket')
+
+        const response = await preAuthInstance.handlePreAuth(
+            request,
+            mockExecutionContext
+        )
+
+        expect(response).toBeUndefined()
+        expect(preAuthInstance['app'].fetch).not.toHaveBeenCalled()
+    })
+
+    it('should ignore authless plugins without a path prefix', async () => {
+        const authlessPlugin = {
+            opts: { requiresAuth: false },
+        }
+        const preAuthInstance = createInstanceWithPlugin(authlessPlugin)
+        const request = new Request('https://example.com/webhooks/stripe')
+
+        const response = await preAuthInstance.handlePreAuth(
+            request,
+            mockExecutionContext
+        )
+
+        expect(response).toBeUndefined()
+        expect(preAuthInstance['app'].fetch).not.toHaveBeenCalled()
     })
 })
 


### PR DESCRIPTION
/claim #71

## Summary
- Add focused Vitest coverage for `StarbaseDB.handlePreAuth` authless plugin routing.
- Cover dynamic `:param` and `*` path prefixes, non-matching paths, auth-required plugins, and authless plugins without a path prefix.
- Keep this scoped to `src/handler.test.ts` with no production behavior changes.

## Verification
- `pnpm exec vitest run src/handler.test.ts` -> 13 tests passed
- `pnpm exec vitest run src/handler.test.ts --coverage.enabled true --coverage.include src/handler.ts --coverage.reporter text --coverage.thresholds.lines=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0` -> passed; `src/handler.ts` reports 65.74% statements / 61.66% branches / 39.28% functions / 67.61% lines in the focused run
- `pnpm exec prettier --check src/handler.test.ts` -> passed
- `git diff --check` -> passed

## Notes
- No UI demo video is included because this is backend/unit-test-only validation coverage; the verification commands above demonstrate the behavior.
- Current main still has unrelated baseline failures in `src/rls/index.test.ts` when running the full suite with coverage.
- Transparency: AI-assisted with Codex; I reviewed the diff and verified locally before submitting.