### PR TITLE
test: cover JSON import payload validation

### DIFF
--- a/src/import/json.test.ts
+++ b/src/import/json.test.ts
@@ -106,6 +106,40 @@ describe('JSON Import Module', () => {
         expect(jsonResponse.error).toBe('No file uploaded')
     })
 
+    it('should reject JSON payloads without a data array', async () => {
+        const invalidPayloads = [
+            {},
+            { data: null },
+            { data: { id: 1, name: 'Alice' } },
+        ]
+
+        for (const payload of invalidPayloads) {
+            const request = new Request('http://localhost', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            })
+
+            const response = await importTableFromJsonRoute(
+                'users',
+                request,
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(response.status).toBe(400)
+            const jsonResponse = (await response.json()) as {
+                error?: string
+                result?: any
+            }
+            expect(jsonResponse.error).toBe(
+                'Invalid JSON format. Expected an object with "data" array and optional "columnMapping".'
+            )
+        }
+
+        expect(executeOperation).not.toHaveBeenCalled()
+    })
+
     it('should successfully insert valid JSON data into the table', async () => {
         vi.mocked(executeOperation).mockResolvedValue([])
 


### PR DESCRIPTION
## Summary
- Add focused Vitest coverage for malformed JSON import payload shapes.
- Cover application/json requests where `data` is missing, `null`, or an object instead of an array.
- Assert the existing 400 validation response is returned and `executeOperation` is not called.

## Bounty / Claim
/claim #71

This is a small test-only coverage slice for #71, separate from the active JSON import multipart upload / column mapping PR.

## Verification
- `./node_modules/.bin/vitest run src/import/json.test.ts` -> 7 tests passed
- `./node_modules/.bin/prettier --check src/import/json.test.ts` -> passed
- `git diff --check` -> passed
- Hidden non-ASCII and CRLF checks on `src/import/json.test.ts` -> no matches

## Notes
- No production behavior changes.
- No paid API required.
- No secrets required.
- Local verification included.
