### PR TITLE
fix: Database dumps do not work on large databases (#59)

### DIFF
--- a/src/export/dump.test.ts
+++ b/src/export/dump.test.ts
@@ -128,6 +128,44 @@ describe('Database Dump Module', () => {
         )
     })
 
+    it('should paginate through large tables instead of loading all rows at once', async () => {
+        // A full page signals there may be more rows, triggering another query.
+        const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+            id: i + 1,
+            name: `User${i + 1}`,
+        }))
+        const partialPage = [{ id: 1001, name: 'User1001' }]
+
+        vi.mocked(executeOperation)
+            .mockResolvedValueOnce([{ name: 'users' }]) // table list
+            .mockResolvedValueOnce([
+                { sql: 'CREATE TABLE users (id INTEGER, name TEXT);' },
+            ]) // schema
+            .mockResolvedValueOnce(fullPage) // data page 1 (full -> fetch more)
+            .mockResolvedValueOnce(partialPage) // data page 2 (partial -> stop)
+
+        const response = await dumpDatabaseRoute(mockDataSource, mockConfig)
+
+        expect(response).toBeInstanceOf(Response)
+        const dumpText = await response.text()
+
+        // tables + schema + 2 data pages
+        expect(executeOperation).toHaveBeenCalledTimes(4)
+        expect(dumpText).toContain("INSERT INTO users VALUES (1, 'User1');")
+        expect(dumpText).toContain(
+            "INSERT INTO users VALUES (1001, 'User1001');"
+        )
+
+        // Data queries should be paginated with LIMIT/OFFSET.
+        const firstDataQuery =
+            vi.mocked(executeOperation).mock.calls[2][0][0].sql
+        const secondDataQuery =
+            vi.mocked(executeOperation).mock.calls[3][0][0].sql
+        expect(firstDataQuery).toContain('LIMIT')
+        expect(firstDataQuery).toContain('OFFSET 0')
+        expect(secondDataQuery).toContain('OFFSET 1000')
+    })
+
     it('should return a 500 response when an error occurs', async () => {
         const consoleErrorMock = vi
             .spyOn(console, 'error')

--- a/src/export/dump.ts
+++ b/src/export/dump.ts
@@ -3,12 +3,18 @@ import { StarbaseDBConfiguration } from '../handler'
 import { DataSource } from '../types'
 import { createResponse } from '../utils'
 
+// Number of rows to read from a table per query. Keeping this bounded means
+// we never materialize an entire (potentially multi-GB) table in memory at
+// once while building the dump.
+const DUMP_PAGE_SIZE = 1000
+
 export async function dumpDatabaseRoute(
     dataSource: DataSource,
     config: StarbaseDBConfiguration
 ): Promise<Response> {
     try {
-        // Get all table names
+        // Get all table names up front so we can fail fast (with a proper 500
+        // response) if the database is unreachable.
         const tablesResult = await executeOperation(
             [{ sql: "SELECT name FROM sqlite_master WHERE type='table';" }],
             dataSource,
@@ -16,54 +22,91 @@ export async function dumpDatabaseRoute(
         )
 
         const tables = tablesResult.map((row: any) => row.name)
-        let dumpContent = 'SQLite format 3\0' // SQLite file header
+        const encoder = new TextEncoder()
 
-        // Iterate through all tables
-        for (const table of tables) {
-            // Get table schema
-            const schemaResult = await executeOperation(
-                [
-                    {
-                        sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
-                    },
-                ],
-                dataSource,
-                config
-            )
+        // Stream the dump out instead of buffering the whole database into a
+        // single string. This keeps memory usage flat regardless of database
+        // size, and because the response body is produced incrementally the
+        // connection stays alive past the 30s request window for large dumps.
+        const stream = new ReadableStream({
+            async start(controller) {
+                try {
+                    controller.enqueue(encoder.encode('SQLite format 3\0')) // SQLite file header
 
-            if (schemaResult.length) {
-                const schema = schemaResult[0].sql
-                dumpContent += `\n-- Table: ${table}\n${schema};\n\n`
-            }
+                    // Iterate through all tables
+                    for (const table of tables) {
+                        // Get table schema
+                        const schemaResult = await executeOperation(
+                            [
+                                {
+                                    sql: `SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}';`,
+                                },
+                            ],
+                            dataSource,
+                            config
+                        )
 
-            // Get table data
-            const dataResult = await executeOperation(
-                [{ sql: `SELECT * FROM ${table};` }],
-                dataSource,
-                config
-            )
+                        if (schemaResult.length) {
+                            const schema = schemaResult[0].sql
+                            controller.enqueue(
+                                encoder.encode(
+                                    `\n-- Table: ${table}\n${schema};\n\n`
+                                )
+                            )
+                        }
 
-            for (const row of dataResult) {
-                const values = Object.values(row).map((value) =>
-                    typeof value === 'string'
-                        ? `'${value.replace(/'/g, "''")}'`
-                        : value
-                )
-                dumpContent += `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
-            }
+                        // Get table data one page at a time so a single large
+                        // table never has to fit in memory all at once.
+                        let offset = 0
+                        while (true) {
+                            const dataResult = await executeOperation(
+                                [
+                                    {
+                                        sql: `SELECT * FROM ${table} LIMIT ${DUMP_PAGE_SIZE} OFFSET ${offset};`,
+                                    },
+                                ],
+                                dataSource,
+                                config
+                            )
 
-            dumpContent += '\n'
-        }
+                            for (const row of dataResult) {
+                                const values = Object.values(row).map(
+                                    (value) =>
+                                        typeof value === 'string'
+                                            ? `'${value.replace(/'/g, "''")}'`
+                                            : value
+                                )
+                                controller.enqueue(
+                                    encoder.encode(
+                                        `INSERT INTO ${table} VALUES (${values.join(', ')});\n`
+                                    )
+                                )
+                            }
 
-        // Create a Blob from the dump content
-        const blob = new Blob([dumpContent], { type: 'application/x-sqlite3' })
+                            // A short page means we've reached the end of the table.
+                            if (dataResult.length < DUMP_PAGE_SIZE) {
+                                break
+                            }
+                            offset += DUMP_PAGE_SIZE
+                        }
+
+                        controller.enqueue(encoder.encode('\n'))
+                    }
+
+                    controller.close()
+                } catch (error: any) {
+                    console.error('Database Dump Error:', error)
+                    controller.error(error)
+                }
+            },
+        })
 
         const headers = new Headers({
             'Content-Type': 'application/x-sqlite3',
             'Content-Disposition': 'attachment; filename="database_dump.sql"',
         })
 
-        return new Response(blob, { headers })
+        return new Response(stream, { headers })
     } catch (error: any) {
         console.error('Database Dump Error:', error)
         return createResponse(undefined, 'Failed to create database dump', 500)


### PR DESCRIPTION
Fixes #59.

/claim #59

emory at once.

Both also meant nothing was sent to the client until the *entire* dump finished, so any dump exceeding the ~30s request window failed with no partial output.

**Fix (`src/export/dump.ts`):**
- The response body is now a `ReadableStream`. Each schema line and `INSERT` statement is `enqueue`d as it's generated, so memory stays flat regardless of database size and bytes start flowing to the client immediately — keeping the connection alive well past the 30s window for large dumps.
- Table data is read in bounded pages via `LIMIT 1000 OFFSET n`, looping until a short page signals end-of-table, so no single large table is ever fully held in memory.
- The initial table-list query stays outside the stream so a dead connection still produces a proper `500` response; errors during streaming go through `controller.error`.

**Test (`src/export/dump.test.ts`):** Added a case that mocks a full 1000-row page followed by a partial page, asserting the dump paginates (4 `executeOperation` calls) and issues `LIMIT`/`OFFSET 0` then `OFFSET 1000` queries. All existing tests still pass unchanged since streamed responses are still readable via `response.text()`.

Note: this is the focused, dependency-free fix. The issue's fuller "proposed solution" (R2 binding, DO alarms, callback URLs) is a much larger feature requiring new infrastructure bindings and config; the streaming + pagination change is the smallest correct fix that removes the memory ceiling and the hard timeout failure.

---
*Verified against the repository's own test suite before submission.*