### PR TITLE
test: cover auth template migration

### DIFF
--- a/templates/auth/src/migration.test.ts
+++ b/templates/auth/src/migration.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
+const migrationSql = readFileSync(new URL('./migration.sql', import.meta.url), {
+    encoding: 'utf8',
+})
+
+let db: InstanceType<typeof DatabaseSync>
+
+function executeMigration() {
+    db.exec('PRAGMA foreign_keys = ON')
+    db.exec(migrationSql)
+}
+
+function insertUser(opts: {
+    username?: string | null
+    email?: string | null
+    password?: string
+}) {
+    return db
+        .prepare(
+            `
+            INSERT INTO auth_users (username, email, password)
+            VALUES (?, ?, ?)
+        `
+        )
+        .run(opts.username ?? null, opts.email ?? null, opts.password ?? 'pw')
+}
+
+describe('auth template migration', () => {
+    beforeEach(() => {
+        db = new DatabaseSync(':memory:')
+        executeMigration()
+    })
+
+    afterEach(() => {
+        db.close()
+    })
+
+    it('creates the auth tables and can be applied more than once', () => {
+        executeMigration()
+
+        const tables = db
+            .prepare(
+                `
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'table' AND name IN ('auth_users', 'auth_sessions')
+                ORDER BY name
+            `
+            )
+            .all()
+
+        expect(tables).toEqual([
+            { name: 'auth_sessions' },
+            { name: 'auth_users' },
+        ])
+    })
+
+    it('requires at least one identity field and permits username-only or email-only users', () => {
+        insertUser({ username: 'manuel' })
+        insertUser({ email: 'manuel@example.com' })
+
+        expect(() => insertUser({})).toThrow()
+    })
+
+    it('rejects case-insensitive username, email, and cross-field identity collisions', () => {
+        insertUser({ username: 'Manuel' })
+        insertUser({ email: 'other@example.com' })
+
+        expect(() => insertUser({ username: 'manuel' })).toThrow()
+        expect(() => insertUser({ email: 'OTHER@example.com' })).toThrow()
+        expect(() => insertUser({ email: 'MANUEL' })).toThrow()
+        expect(() => insertUser({ username: 'other@example.com' })).toThrow()
+    })
+
+    it('enforces session ownership and unique session tokens', () => {
+        const user = insertUser({ username: 'session-user' })
+
+        const insertSession = db.prepare(
+            `
+            INSERT INTO auth_sessions (user_id, session_token)
+            VALUES (?, ?)
+        `
+        )
+
+        insertSession.run(user.lastInsertRowid, 'session-token')
+
+        expect(() =>
+            insertSession.run(user.lastInsertRowid, 'session-token')
+        ).toThrow()
+        expect(() => insertSession.run(999, 'other-token')).toThrow()
+    })
+})


### PR DESCRIPTION
## Summary

/claim #71

Adds focused Vitest coverage for `templates/auth/src/migration.sql` by executing the migration in an in-memory SQLite database and asserting the behavior the auth template relies on:

- migration is idempotent and creates `auth_users` / `auth_sessions`
- users must have at least one identity field while username-only and email-only users are valid
- username/email uniqueness is case-insensitive and prevents cross-field collisions
- sessions enforce valid `user_id` ownership and unique session tokens

This is intentionally test-only and does not change production behavior.

## Verification

- `corepack pnpm exec vitest run templates/auth/src/migration.test.ts` -> 4 tests passed
- `corepack pnpm exec prettier --check templates/auth/src/migration.test.ts` -> passed
- `git diff --check` -> passed

## Baseline notes

- `corepack pnpm test -- run` currently fails in the existing RLS baseline: 4 failures in `src/rls/index.test.ts` where policy predicates are not added to SELECT/JOIN/subquery SQL.
- `corepack pnpm exec tsc --noEmit --pretty false` currently fails on existing type errors in `plugins/cdc/index.test.ts`, `plugins/cdc/index.ts`, `src/cache/index.test.ts`, `src/do.test.ts`, and `src/operation.ts`.

Transparency: AI-assisted with OpenAI Codex; I reviewed the diff and verified the focused test locally.