### PR TITLE
Quote table identifiers for CSV and JSON exports

### DIFF
--- a/src/export/index.test.ts
+++ b/src/export/index.test.ts
@@ -83,6 +83,57 @@ describe('Database Operations Module', () => {
             ])
         })
 
+        it('should quote table names that require identifiers in data queries', async () => {
+            vi.mocked(executeTransaction)
+                .mockResolvedValueOnce([{ name: "kid's profiles" }])
+                .mockResolvedValueOnce([{ id: 1, name: 'Alice' }])
+
+            const result = await getTableData(
+                "kid's profiles",
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(executeTransaction).toHaveBeenNthCalledWith(1, {
+                queries: [
+                    {
+                        sql: "SELECT name FROM sqlite_master WHERE type='table' AND name=?;",
+                        params: ["kid's profiles"],
+                    },
+                ],
+                isRaw: false,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
+            expect(executeTransaction).toHaveBeenNthCalledWith(2, {
+                queries: [{ sql: 'SELECT * FROM "kid\'s profiles";' }],
+                isRaw: false,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
+            expect(result).toEqual([{ id: 1, name: 'Alice' }])
+        })
+
+        it('should quote reserved table names in data queries', async () => {
+            vi.mocked(executeTransaction)
+                .mockResolvedValueOnce([{ name: 'order' }])
+                .mockResolvedValueOnce([{ id: 1 }])
+
+            const result = await getTableData(
+                'order',
+                mockDataSource,
+                mockConfig
+            )
+
+            expect(executeTransaction).toHaveBeenNthCalledWith(2, {
+                queries: [{ sql: 'SELECT * FROM "order";' }],
+                isRaw: false,
+                dataSource: mockDataSource,
+                config: mockConfig,
+            })
+            expect(result).toEqual([{ id: 1 }])
+        })
+
         it('should return null if table does not exist', async () => {
             vi.mocked(executeTransaction).mockResolvedValueOnce([])
 

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -2,6 +2,36 @@ import { DataSource } from '../types'
 import { executeTransaction } from '../operation'
 import { StarbaseDBConfiguration } from '../handler'
 
+const sqliteKeywords = new Set([
+    'select',
+    'from',
+    'where',
+    'table',
+    'index',
+    'insert',
+    'values',
+    'order',
+    'group',
+    'by',
+    'limit',
+    'offset',
+    'join',
+    'on',
+    'and',
+    'or',
+])
+
+function formatIdentifier(identifier: string) {
+    if (
+        /^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier) &&
+        !sqliteKeywords.has(identifier.toLowerCase())
+    ) {
+        return identifier
+    }
+
+    return `"${identifier.replace(/"/g, '""')}"`
+}
+
 export async function executeOperation(
     queries: { sql: string; params?: any[] }[],
     dataSource: DataSource,
@@ -43,7 +73,7 @@ export async function getTableData(
 
         // Get table data
         const dataResult = await executeOperation(
-            [{ sql: `SELECT * FROM ${tableName};` }],
+            [{ sql: `SELECT * FROM ${formatIdentifier(tableName)};` }],
             dataSource,
             config
         )


### PR DESCRIPTION
/claim #59

## Summary
- quote table identifiers in the shared `getTableData()` data query used by CSV and JSON exports
- preserve the existing parameterized sqlite_master existence check
- add regression coverage for table names containing a quote and for reserved table names like `order`

This is a separate, scoped follow-up to the SQL dump identifier fix and avoids the broader streaming/R2 export implementations.

## Verification
- pnpm exec vitest run src/export/index.test.ts src/export/csv.test.ts src/export/json.test.ts
- pnpm exec prettier --check src/export/index.ts src/export/index.test.ts
- git diff --check
- pnpm run build

## Demo
- The focused tests verify that `getTableData()` keeps table existence lookup parameterized while emitting quoted SELECTs for `kid's profiles` and `order`.