### PR TITLE
test: cover malformed query cache fallback

### DIFF
--- a/src/cache/index.test.ts
+++ b/src/cache/index.test.ts
@@ -78,6 +78,34 @@ describe('Cache Module', () => {
             expect(result).toEqual([{ id: 1, name: 'John' }])
         })
 
+        it('should return null if cached result JSON is malformed', async () => {
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => {})
+            const cachedData = {
+                timestamp: new Date().toISOString(),
+                ttl: 300,
+                results: '{"id":',
+            }
+
+            vi.mocked(mockDataSource.rpc.executeQuery).mockResolvedValue([
+                cachedData,
+            ])
+
+            const result = await beforeQueryCache({
+                sql: 'SELECT * FROM users',
+                params: [],
+                dataSource: mockDataSource,
+            })
+
+            expect(result).toBeNull()
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Error parsing cached query results:',
+                expect.any(SyntaxError)
+            )
+            consoleSpy.mockRestore()
+        })
+
         it('should return null if cache is expired', async () => {
             const expiredCache = {
                 timestamp: new Date(Date.now() - 1000 * 3600).toISOString(), // 1 hour old

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -72,7 +72,12 @@ export async function beforeQueryCache(opts: {
         const expirationTime = new Date(timestamp).getTime() + ttl * 1000
 
         if (Date.now() < expirationTime) {
-            return JSON.parse(results)
+            try {
+                return JSON.parse(results)
+            } catch (error) {
+                console.error('Error parsing cached query results:', error)
+                return null
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Treat a fresh cache row with malformed JSON as a cache miss instead of throwing out of `beforeQueryCache`.
- Log the parse failure so corrupt cache rows remain diagnosable.
- Add focused Vitest coverage for the malformed cached-result path in `src/cache/index.test.ts`.

/claim #71

## Validation
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm exec vitest run src/cache/index.test.ts` -> 15 tests passed
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm exec vitest run src/cache/index.test.ts --coverage.enabled true --coverage.include src/cache/index.ts --coverage.reporter text --coverage.thresholds.lines=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0` -> passed; `src/cache/index.ts` at 89.79% statements / 81.39% branches / 100% functions / 88.88% lines
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm exec prettier --check src/cache/index.ts src/cache/index.test.ts` -> passed
- `git diff --check` -> passed

## Notes
- Full suite still has the existing unrelated RLS failures in `src/rls/index.test.ts` (4 failing assertions); `src/cache/index.test.ts` passes within that run.
- No UI demo video is included because this is a backend/unit-test-only cache coverage change with no visible UI surface.
