### PR TITLE
test: cover durable object bootstrap helpers

### DIFF
--- a/src/do.test.ts
+++ b/src/do.test.ts
@@ -102,50 +102,89 @@ describe('StarbaseDBDurableObject Tests', () => {
         new StarbaseDBDurableObject(mockDurableObjectState, mockEnv)
 
         const executedSql = mockStorage.sql.exec.mock.calls.map(([sql]) => sql)
-        expect(executedSql).toHaveLength(4)
-        expect(executedSql[0]).toContain('CREATE TABLE IF NOT EXISTS tmp_cache')
-        expect(executedSql[1]).toContain(
-            'CREATE TABLE IF NOT EXISTS tmp_allowlist_queries'
+        expect(executedSql).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining('CREATE TABLE IF NOT EXISTS tmp_cache'),
+                expect.stringContaining(
+                    'CREATE TABLE IF NOT EXISTS tmp_allowlist_queries'
+                ),
+                expect.stringContaining(
+                    'CREATE TABLE IF NOT EXISTS tmp_allowlist_rejections'
+                ),
+                expect.stringContaining(
+                    'CREATE TABLE IF NOT EXISTS tmp_rls_policies'
+                ),
+            ])
         )
-        expect(executedSql[2]).toContain(
-            'CREATE TABLE IF NOT EXISTS tmp_allowlist_rejections'
-        )
-        expect(executedSql[3]).toContain(
-            'CREATE TABLE IF NOT EXISTS tmp_rls_policies'
-        )
+
+        const bootstrapSql = executedSql.join('\n')
+        expect(bootstrapSql).toContain('"query" TEXT UNIQUE NOT NULL')
+        expect(bootstrapSql).toContain('sql_statement TEXT NOT NULL')
+        expect(bootstrapSql).toContain('created_at TEXT DEFAULT')
+        expect(bootstrapSql).toContain('CHECK(actions IN')
     })
 
     it('should expose bound Durable Object helper methods from init()', async () => {
         const getAlarm = vi.fn().mockResolvedValue(123)
         const setAlarm = vi.fn().mockResolvedValue(undefined)
         const deleteAlarm = vi.fn().mockResolvedValue(undefined)
+        const sqlExec = vi.fn().mockReturnValue({
+            columnNames: ['count'],
+            raw: vi.fn().mockReturnValue([[3]]),
+            toArray: vi.fn().mockReturnValue([{ count: 3 }]),
+            rowsRead: 1,
+            rowsWritten: 0,
+        })
         const storage = {
-            ...mockStorage,
+            sql: {
+                exec: sqlExec,
+                databaseSize: 4096,
+            },
             getAlarm,
             setAlarm,
             deleteAlarm,
         }
-        const initialized = new StarbaseDBDurableObject(
+        const durableObject = new StarbaseDBDurableObject(
             { storage, getTags: vi.fn().mockReturnValue([]) } as any,
             mockEnv
-        ).init()
+        )
+        const initialized = durableObject.init()
+        sqlExec.mockClear()
 
         await expect(initialized.getAlarm()).resolves.toBe(123)
         await initialized.setAlarm(Date.now() + 2000)
         await initialized.deleteAlarm()
+        await expect(initialized.getStatistics()).resolves.toEqual({
+            databaseSize: 4096,
+            activeConnections: 0,
+            recentQueries: 3,
+        })
         await expect(
-            initialized.executeQuery({ sql: 'SELECT * FROM users' })
-        ).resolves.toEqual([
-            { id: 1, name: 'Alice' },
-            { id: 2, name: 'Bob' },
-        ])
+            initialized.executeQuery({
+                sql: 'SELECT count(*) FROM tmp_query_log',
+            })
+        ).resolves.toEqual([{ count: 3 }])
 
         expect(getAlarm).toHaveBeenCalledOnce()
         expect(setAlarm).toHaveBeenCalledOnce()
         expect(deleteAlarm).toHaveBeenCalledOnce()
+        expect(sqlExec).toHaveBeenCalledWith(
+            expect.stringContaining('FROM tmp_query_log')
+        )
+        expect(sqlExec).toHaveBeenCalledWith(
+            'SELECT count(*) FROM tmp_query_log'
+        )
     })
 
     it('should execute a raw query with params and return cursor metadata', async () => {
+        mockStorage.sql.exec.mockReturnValueOnce({
+            columnNames: ['id', 'name'],
+            raw: vi.fn().mockReturnValue([[1, 'Alice']]),
+            toArray: vi.fn(),
+            rowsRead: 1,
+            rowsWritten: 0,
+        })
+
         const result = await instance.executeQuery({
             sql: 'SELECT * FROM users WHERE id = ?',
             params: [1],
@@ -158,13 +197,10 @@ describe('StarbaseDBDurableObject Tests', () => {
         )
         expect(result).toEqual({
             columns: ['id', 'name'],
-            rows: [
-                [1, 'Alice'],
-                [2, 'Bob'],
-            ],
+            rows: [[1, 'Alice']],
             meta: {
-                rows_read: 2,
-                rows_written: 1,
+                rows_read: 1,
+                rows_written: 0,
             },
         })
     })

--- a/src/do.test.ts
+++ b/src/do.test.ts
@@ -96,6 +96,79 @@ describe('StarbaseDBDurableObject Tests', () => {
         expect(instance.storage).toBeDefined()
     })
 
+    it('should bootstrap internal temporary tables during construction', () => {
+        vi.clearAllMocks()
+
+        new StarbaseDBDurableObject(mockDurableObjectState, mockEnv)
+
+        const executedSql = mockStorage.sql.exec.mock.calls.map(([sql]) => sql)
+        expect(executedSql).toHaveLength(4)
+        expect(executedSql[0]).toContain('CREATE TABLE IF NOT EXISTS tmp_cache')
+        expect(executedSql[1]).toContain(
+            'CREATE TABLE IF NOT EXISTS tmp_allowlist_queries'
+        )
+        expect(executedSql[2]).toContain(
+            'CREATE TABLE IF NOT EXISTS tmp_allowlist_rejections'
+        )
+        expect(executedSql[3]).toContain(
+            'CREATE TABLE IF NOT EXISTS tmp_rls_policies'
+        )
+    })
+
+    it('should expose bound Durable Object helper methods from init()', async () => {
+        const getAlarm = vi.fn().mockResolvedValue(123)
+        const setAlarm = vi.fn().mockResolvedValue(undefined)
+        const deleteAlarm = vi.fn().mockResolvedValue(undefined)
+        const storage = {
+            ...mockStorage,
+            getAlarm,
+            setAlarm,
+            deleteAlarm,
+        }
+        const initialized = new StarbaseDBDurableObject(
+            { storage, getTags: vi.fn().mockReturnValue([]) } as any,
+            mockEnv
+        ).init()
+
+        await expect(initialized.getAlarm()).resolves.toBe(123)
+        await initialized.setAlarm(Date.now() + 2000)
+        await initialized.deleteAlarm()
+        await expect(
+            initialized.executeQuery({ sql: 'SELECT * FROM users' })
+        ).resolves.toEqual([
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' },
+        ])
+
+        expect(getAlarm).toHaveBeenCalledOnce()
+        expect(setAlarm).toHaveBeenCalledOnce()
+        expect(deleteAlarm).toHaveBeenCalledOnce()
+    })
+
+    it('should execute a raw query with params and return cursor metadata', async () => {
+        const result = await instance.executeQuery({
+            sql: 'SELECT * FROM users WHERE id = ?',
+            params: [1],
+            isRaw: true,
+        })
+
+        expect(mockStorage.sql.exec).toHaveBeenCalledWith(
+            'SELECT * FROM users WHERE id = ?',
+            1
+        )
+        expect(result).toEqual({
+            columns: ['id', 'name'],
+            rows: [
+                [1, 'Alice'],
+                [2, 'Bob'],
+            ],
+            meta: {
+                rows_read: 2,
+                rows_written: 1,
+            },
+        })
+    })
+
     it('should execute a query and return results', async () => {
         const sql = 'SELECT * FROM users'
         const result = await instance.executeQuery({ sql })


### PR DESCRIPTION
## Summary
- Add focused Vitest coverage for `StarbaseDBDurableObject` bootstrap behavior.
- Cover constructor-created internal temp tables (`tmp_cache`, allowlist tables, RLS policies).
- Cover `init()` returning bound helper methods and raw query cursor metadata for parameterized queries.

This is intentionally test-only and scoped to `src/do.test.ts`.

## Bounty
/claim #71

## Validation
- `corepack pnpm exec vitest run src/do.test.ts` -> 9 tests passed
- `corepack pnpm exec prettier --check src/do.test.ts` -> passed
- `git diff --check` -> passed
- `corepack pnpm exec vitest run --coverage --coverage.reporter=json-summary --coverage.reporter=text-summary` -> existing unrelated RLS baseline failures remain; this PR improves `src/do.ts` coverage from 41.17% to 51.96% lines, 37.5% to 62.5% functions, and 17.64% to 29.41% branches.

Full-suite baseline note: current `main` already fails four `src/rls/index.test.ts` assertions and the global branch threshold before this PR's changes.

## Demo
This is a test-only coverage PR; the focused terminal verification above demonstrates the change.