### PR TITLE
test: add Vitest coverage for interface utilities

### DIFF
--- a/plugins/interface/utils/index.test.tsx
+++ b/plugins/interface/utils/index.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import manifest from '../../../public/.vite/manifest.json'
+import { cn, getAssetImportTagsFromManifest } from './index'
+
+type RenderableTag = {
+    toString(): string | Promise<string>
+}
+
+type ManifestEntry = (typeof manifest)[keyof typeof manifest]
+
+async function renderTags(
+    tags: Awaited<ReturnType<typeof getAssetImportTagsFromManifest>>
+) {
+    if (!tags) return null
+
+    return Promise.all(
+        tags.map((tag) =>
+            Promise.resolve((tag as unknown as RenderableTag).toString())
+        )
+    )
+}
+
+const manifestEntries = Object.values(manifest) as ManifestEntry[]
+const sharedEntries = manifestEntries.filter(
+    (entry) =>
+        entry.file.includes('vendor.') || entry.file.includes('components.')
+)
+const additionalCss = manifestEntries.flatMap((entry) => {
+    if (!('css' in entry) || !Array.isArray(entry.css)) return []
+    return entry.css.filter((cssPath) => !cssPath.includes('global'))
+})
+const globalCssEntry = manifestEntries.find((entry) =>
+    entry.file.includes('global')
+)
+const templateEntry = manifestEntries.find((entry) =>
+    entry.file.includes('template.')
+)
+
+function expectedBaseTagCount() {
+    return (
+        sharedEntries.length +
+        additionalCss.length +
+        (globalCssEntry?.file ? 1 : 0)
+    )
+}
+
+function expectSharedAssets(rendered: string[]) {
+    for (const entry of sharedEntries) {
+        expect(rendered).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(`src="/${entry.file}"`),
+            ])
+        )
+    }
+
+    for (const cssPath of additionalCss) {
+        expect(rendered).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(`href="/${cssPath}"`),
+            ])
+        )
+    }
+
+    if (globalCssEntry?.file) {
+        expect(rendered).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(`href="/${globalCssEntry.file}"`),
+            ])
+        )
+    }
+}
+
+describe('interface utils - cn()', () => {
+    it('combines ordinary and conditional class values', () => {
+        expect(
+            cn('text-sm', { 'font-bold': true, italic: false }, undefined)
+        ).toBe('text-sm font-bold')
+    })
+
+    it('keeps the last conflicting Tailwind utility', () => {
+        expect(cn('px-2', 'px-4', 'text-red-500', 'text-blue-500')).toBe(
+            'px-4 text-blue-500'
+        )
+    })
+})
+
+describe('interface utils - getAssetImportTagsFromManifest()', () => {
+    it('includes the current page script plus shared JS and CSS assets', async () => {
+        expect(templateEntry).toBeDefined()
+
+        const rendered = await renderTags(
+            await getAssetImportTagsFromManifest('template')
+        )
+
+        expect(rendered).not.toBeNull()
+        expectSharedAssets(rendered!)
+        expect(rendered).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(`src="/${templateEntry!.file}"`),
+            ])
+        )
+        expect(rendered).toHaveLength(expectedBaseTagCount() + 1)
+    })
+
+    it('omits an unrelated page script while retaining shared assets', async () => {
+        expect(templateEntry).toBeDefined()
+
+        const rendered = await renderTags(
+            await getAssetImportTagsFromManifest('not-a-real-page')
+        )
+
+        expect(rendered).not.toBeNull()
+        expectSharedAssets(rendered!)
+        expect(rendered).toHaveLength(expectedBaseTagCount())
+        expect(
+            rendered!.some((tag) =>
+                tag.includes(`src="/${templateEntry!.file}"`)
+            )
+        ).toBe(false)
+    })
+
+    it('includes shared assets when no current page is supplied', async () => {
+        expect(templateEntry).toBeDefined()
+
+        const rendered = await renderTags(await getAssetImportTagsFromManifest())
+
+        expect(rendered).not.toBeNull()
+        expectSharedAssets(rendered!)
+        expect(rendered).toHaveLength(expectedBaseTagCount())
+        expect(
+            rendered!.some((tag) =>
+                tag.includes(`src="/${templateEntry!.file}"`)
+            )
+        ).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary

Adds focused Vitest coverage for `plugins/interface/utils/index.tsx` without changing production behavior.

### Covered behavior
- `cn()` combines conditional classes correctly.
- `cn()` resolves conflicting Tailwind utilities using the last applicable class.
- `getAssetImportTagsFromManifest()` includes the current page's JS entry.
- Shared `vendor` and `components` chunks are included.
- CSS assets from the Vite manifest are included.
- Unrelated page scripts are excluded.
- Calling the helper without a current page still includes shared assets.
- Expectations are derived from `manifest.json`, avoiding brittle hard-coded Vite hashes.

## Verification

Local simulation performed against the current `plugins/interface/utils/index.tsx` logic and committed `public/.vite/manifest.json`:

- strict TypeScript compatibility simulation: PASS
- executable behavior simulation: PASS

The upstream repository CI should still be treated as authoritative because this execution environment could not download the repository dependencies directly.

## Demo

Short visual walkthrough attached below. It clearly distinguishes the local simulation from authoritative upstream CI.

/claim #71

https://github.com/user-attachments/assets/9fef0b1c-b2d1-4427-b5df-393be3e75cfe

