### PR TITLE
fix: close Hyperdrive client after query failures

### DIFF
--- a/src/operation.hyperdrive.test.ts
+++ b/src/operation.hyperdrive.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { executeQuery } from './operation'
+import type { DataSource } from './types'
+import type { StarbaseDBConfiguration } from './handler'
+
+const client = vi.hoisted(() => ({ unsafe: vi.fn(), end: vi.fn() }))
+
+vi.mock('postgres', () => ({ default: vi.fn(() => client) }))
+vi.mock('./allowlist', () => ({ isQueryAllowed: vi.fn() }))
+vi.mock('./rls', () => ({ applyRLS: vi.fn(async ({ sql }) => sql) }))
+vi.mock('./cache', () => ({
+    beforeQueryCache: vi.fn(async () => null),
+    afterQueryCache: vi.fn(),
+}))
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    client.unsafe.mockReset().mockResolvedValue([{ id: 1 }])
+    client.end.mockReset().mockResolvedValue(undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('Hyperdrive connection lifecycle', () => {
+    for (const background of [false, true]) {
+        const mode = background ? 'with waitUntil' : 'without waitUntil'
+
+        function run(waitUntil: ReturnType<typeof vi.fn>) {
+            return executeQuery({
+                sql: 'SELECT id FROM records WHERE id = $1',
+                params: [1],
+                isRaw: false,
+                dataSource: {
+                    source: 'hyperdrive',
+                    external: { connectionString: 'postgres://localhost/test' },
+                    ...(background ? { executionContext: { waitUntil } } : {}),
+                } as unknown as DataSource,
+                config: {
+                    role: 'admin',
+                    features: {},
+                } as StarbaseDBConfiguration,
+            })
+        }
+
+        it(`closes the client after success ${mode}`, async () => {
+            const waitUntil = vi.fn()
+            await expect(run(waitUntil)).resolves.toEqual([{ id: 1 }])
+            expect(client.unsafe).toHaveBeenCalledWith(
+                'SELECT id FROM records WHERE id = $1',
+                [1]
+            )
+            expect(client.end).toHaveBeenCalledTimes(1)
+            if (background) {
+                expect(waitUntil).toHaveBeenCalledWith(
+                    client.end.mock.results[0].value
+                )
+            } else {
+                expect(waitUntil).not.toHaveBeenCalled()
+            }
+        })
+
+        it(`closes the client and preserves query failure ${mode}`, async () => {
+            const failure = new Error('query failed')
+            client.unsafe.mockRejectedValueOnce(failure)
+            const waitUntil = vi.fn()
+            await expect(run(waitUntil)).rejects.toBe(failure)
+            expect(client.end).toHaveBeenCalledTimes(1)
+            if (background) {
+                expect(waitUntil).toHaveBeenCalledWith(
+                    client.end.mock.results[0].value
+                )
+            } else {
+                expect(waitUntil).not.toHaveBeenCalled()
+            }
+        })
+    }
+})

--- a/src/operation.hyperdrive.test.ts
+++ b/src/operation.hyperdrive.test.ts
@@ -74,5 +74,52 @@ describe('Hyperdrive connection lifecycle', () => {
                 expect(waitUntil).not.toHaveBeenCalled()
             }
         })
+
+        it.each([new Error('query failed'), undefined])(
+            `preserves query rejection %s when cleanup also rejects ${mode}`,
+            async (failure) => {
+                const cleanupFailure = new Error('cleanup failed')
+                client.unsafe.mockRejectedValueOnce(failure)
+                client.end.mockRejectedValueOnce(cleanupFailure)
+                // Model the runtime observing background rejection, without
+                // leaving an unhandled promise rejection in the test process.
+                const waitUntil = vi.fn((promise: Promise<unknown>) => {
+                    void promise.catch(() => {})
+                })
+
+                await expect(run(waitUntil)).rejects.toBe(failure)
+                expect(client.end).toHaveBeenCalledTimes(1)
+                if (background) {
+                    const cleanup = client.end.mock.results[0].value
+                    expect(waitUntil).toHaveBeenCalledWith(cleanup)
+                    await expect(cleanup).rejects.toBe(cleanupFailure)
+                } else {
+                    expect(waitUntil).not.toHaveBeenCalled()
+                    expect(console.error).toHaveBeenCalledWith(
+                        'Hyperdrive cleanup error:',
+                        cleanupFailure
+                    )
+                }
+            }
+        )
+
+        it(`reports cleanup failure after query success ${mode}`, async () => {
+            const cleanupFailure = new Error('cleanup failed')
+            client.end.mockRejectedValueOnce(cleanupFailure)
+            const waitUntil = vi.fn((promise: Promise<unknown>) => {
+                void promise.catch(() => {})
+            })
+
+            if (background) {
+                await expect(run(waitUntil)).resolves.toEqual([{ id: 1 }])
+                const cleanup = client.end.mock.results[0].value
+                expect(waitUntil).toHaveBeenCalledWith(cleanup)
+                await expect(cleanup).rejects.toBe(cleanupFailure)
+            } else {
+                await expect(run(waitUntil)).rejects.toBe(cleanupFailure)
+                expect(waitUntil).not.toHaveBeenCalled()
+            }
+            expect(client.end).toHaveBeenCalledTimes(1)
+        })
     }
 })

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -274,19 +274,27 @@ export async function executeQuery(opts: {
             fetch_types: false,
         })
 
+        let queryFailed = false
         try {
             result = await sql.unsafe(updatedSQL, updatedParams as any[])
         } catch (e) {
+            queryFailed = true
             console.error('Hyperdrive query error:', e)
             throw e
         } finally {
-            if (opts.dataSource?.executionContext) {
-                // Optimistically we hope a ExecutionContext is available to us
-                // to properly end our SQL function.
-                opts.dataSource?.executionContext?.waitUntil(sql.end())
-            } else {
-                // As a fallback we'll just end it.
-                await sql.end()
+            try {
+                if (opts.dataSource?.executionContext) {
+                    // Optimistically we hope a ExecutionContext is available to us
+                    // to properly end our SQL function.
+                    opts.dataSource?.executionContext?.waitUntil(sql.end())
+                } else {
+                    // As a fallback we'll just end it.
+                    await sql.end()
+                }
+            } catch (e) {
+                console.error('Hyperdrive cleanup error:', e)
+                // A cleanup failure must not replace the original query rejection.
+                if (!queryFailed) throw e
             }
         }
     } else {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -276,7 +276,10 @@ export async function executeQuery(opts: {
 
         try {
             result = await sql.unsafe(updatedSQL, updatedParams as any[])
-
+        } catch (e) {
+            console.error('Hyperdrive query error:', e)
+            throw e
+        } finally {
             if (opts.dataSource?.executionContext) {
                 // Optimistically we hope a ExecutionContext is available to us
                 // to properly end our SQL function.
@@ -285,9 +288,6 @@ export async function executeQuery(opts: {
                 // As a fallback we'll just end it.
                 await sql.end()
             }
-        } catch (e) {
-            console.error('Hyperdrive query error:', e)
-            throw e
         }
     } else {
         result = await executeExternalQuery({


### PR DESCRIPTION
## Problem

A failed Hyperdrive query skips `sql.end()` in the base implementation. Moving cleanup into `finally` fixes that leak, but an awaited cleanup rejection can then hide the original query rejection.

## Change

- Always close the Hyperdrive client after query success or failure.
- Preserve the original query rejection if cleanup also fails, including an `undefined` rejection reason.
- Keep cleanup-only errors visible and preserve background cleanup through `executionContext.waitUntil()`.
- Add ten focused lifecycle regression tests with a mocked Postgres client.

## Verification

Base: `bb227352135051a0dd50190d67c3e82b03f8e485`. Updated head: `958168e4086f5b1b0f0dbe75400193eb06c5c93a`.

- Original leak: two rejection-cleanup tests failed before the initial fix.
- Dual-failure regression against previous draft head `bec45944ec3464ec1e2364a143c213f659bf4ed7`: 2 failed, 8 passed.
- Updated `vitest run src/operation.hyperdrive.test.ts src/operation.test.ts`: **21 passed**.
- Full suite: 161 passed, 4 RLS failures. Previous draft head: 155 passed, the same 4 failures.
- Typecheck: the same 11 diagnostics at both revisions, apart from shifted source locations.
- Prettier and `git diff --check` pass.

These are local Node 22.23.2 / Vitest 2.1.8 tests; no live Hyperdrive deployment was tested. The repository CI uses Node 20, which was not tested locally.

## Short demonstration

Recorded local regression results, not a deployment recording:

https://github.com/user-attachments/assets/64f8ece1-1255-4c74-a04e-bed55dc6b05f

## Scope

Related to #71. This is a narrow regression contribution, not completion of the repository-wide 75% coverage goal. #153 covers successful Hyperdrive cleanup; this change covers query-rejection cleanup and simultaneous failures. No reward has been agreed for this slice; keeping this draft pending scope/eligibility confirmation.
